### PR TITLE
Fix 26

### DIFF
--- a/apputils/model_summaries.py
+++ b/apputils/model_summaries.py
@@ -31,6 +31,7 @@ import torch.jit as jit
 import pandas as pd
 from tabulate import tabulate
 import pydot
+import distiller
 
 
 def onnx_name_2_pytorch_name(name, op_type):
@@ -90,7 +91,7 @@ class SummaryGraph(object):
 
     def __init__(self, model, dummy_input):
         with torch.onnx.set_training(model, False):
-            trace, _ = jit.get_trace_graph(model, dummy_input)
+            trace, _ = jit.get_trace_graph(model, dummy_input.cuda())
 
             # Let ONNX do the heavy lifting: fusing the convolution nodes; fusing the nodes
             # composing a GEMM operation; etc.
@@ -588,6 +589,7 @@ def draw_img_classifier_to_file(model, png_fname, dataset, display_param_nodes=F
             print("Unsupported dataset (%s) - aborting draw operation" % dataset)
             return
 
+        model = distiller.make_non_parallel_copy(model)
         g = SummaryGraph(model, dummy_input)
         draw_model_to_file(g, png_fname, display_param_nodes, rankdir, styles)
         print("Network PNG image generation completed")

--- a/distiller/model_summaries.py
+++ b/distiller/model_summaries.py
@@ -188,11 +188,14 @@ def model_performance_summary(model, dummy_input, batch_size=1):
 
     hook_handles = []
     memo = []
+
+    model = distiller.make_non_parallel_copy(model)
     model.apply(install_perf_collector)
     # Now run the forward path and collect the data
-    model(dummy_input);
+    model(dummy_input.cuda())
     # Unregister from the forward hooks
-    for handle in hook_handles: handle.remove()
+    for handle in hook_handles:
+        handle.remove()
 
     return df
 

--- a/distiller/model_summaries.py
+++ b/distiller/model_summaries.py
@@ -170,11 +170,7 @@ def module_visitor(self, input, output, df, model, weights_vol, macs, attrs=None
 
 
 def model_performance_summary(model, dummy_input, batch_size=1):
-    """Collect performance data
-
-    warning: in PyTorch 0.4 this function does not return correct values when
-    the graph contains torch.nn.DataParallel layers.
-    """
+    """Collect performance data"""
     def install_perf_collector(m):
         if isinstance(m, torch.nn.Conv2d):
             hook_handles.append(m.register_forward_hook(

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -160,8 +160,7 @@ class CompressionScheduler(object):
         masks = {}
         for name, masker in self.zeros_mask_dict.items():
             masks[name] = masker.mask
-        state = {'masks_dict': masks,
-                 'parallel_model': isinstance(self.model, torch.nn.DataParallel)}
+        state = {'masks_dict': masks}
         return state
 
     def load_state_dict(self, state):
@@ -184,17 +183,6 @@ class CompressionScheduler(object):
                 print("\t\t" + k)
             exit(1)
 
-        curr_model_parallel = isinstance(self.model, torch.nn.DataParallel)
-        # Fallback to 'True' for old checkpoints that don't have this attribute, since parallel=True is the
-        # default for create_model
-        loaded_model_parallel = state.get('parallel_model', True)
         for name, mask in self.zeros_mask_dict.items():
-            # DataParallel modules wrap the actual module with a module named "module"...
-            if loaded_model_parallel and not curr_model_parallel:
-                load_name = 'module.' + name
-            elif curr_model_parallel and not loaded_model_parallel:
-                load_name = name.replace('module.', '', 1)
-            else:
-                load_name = name
             masker = self.zeros_mask_dict[name]
-            masker.mask = loaded_masks[load_name]
+            masker.mask = loaded_masks[name]

--- a/distiller/thinning.py
+++ b/distiller/thinning.py
@@ -18,7 +18,7 @@
 
 Thinning a model is the process of taking a dense network architecture with a parameter model that
 has structure-sparsity (filters or channels) in the weights tensors of convolution layers, and making changes
- in the network architecture and parameters, in order to completely remove the structures.
+in the network architecture and parameters, in order to completely remove the structures.
 The new architecture is smaller (condensed), with less channels and filters in some of the convolution layers.
 Linear and BatchNormalization layers are also adjusted as required.
 

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -209,9 +209,7 @@ def main():
     args.dataset = 'cifar10' if 'cifar' in args.arch else 'imagenet'
 
     # Create the model
-    png_summary = args.summary is not None and args.summary.startswith('png')
-    is_parallel = not png_summary and args.summary != 'compute'  # For PNG summary, parallel graphs are illegible
-    model = create_model(args.pretrained, args.dataset, args.arch, parallel=is_parallel, device_ids=args.gpus)
+    model = create_model(args.pretrained, args.dataset, args.arch, device_ids=args.gpus)
 
     compression_scheduler = None
     # Create a couple of logging backends.  TensorBoardLogger writes log files in a format

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -70,8 +70,9 @@ def create_model(pretrained, dataset, arch, parallel=True, device_ids=None):
 
     if (arch.startswith('alexnet') or arch.startswith('vgg')) and parallel:
         model.features = torch.nn.DataParallel(model.features, device_ids=device_ids)
-        model.cuda()
     elif parallel:
         model = torch.nn.DataParallel(model, device_ids=device_ids).cuda()
+
+    model.cuda()
 
     return model

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -71,8 +71,7 @@ def create_model(pretrained, dataset, arch, parallel=True, device_ids=None):
     if (arch.startswith('alexnet') or arch.startswith('vgg')) and parallel:
         model.features = torch.nn.DataParallel(model.features, device_ids=device_ids)
     elif parallel:
-        model = torch.nn.DataParallel(model, device_ids=device_ids).cuda()
+        model = torch.nn.DataParallel(model, device_ids=device_ids)
 
     model.cuda()
-
     return model

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,8 +23,8 @@ import distiller
 from models import create_model
 
 
-def setup_test(arch, dataset):
-    model = create_model(False, dataset, arch, parallel=False)
+def setup_test(arch, dataset, parallel=True):
+    model = create_model(False, dataset, arch, parallel=parallel)
     assert model is not None
 
     # Create the masks

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -167,7 +167,7 @@ def create_channels_mask(conv_p, channels_to_remove):
     mask = channels.expand(num_filters, num_channels)
     mask.unsqueeze_(-1)
     mask.unsqueeze_(-1)
-    mask = mask.expand(num_filters, num_channels, kernel_height, kernel_width).contiguous()
+    mask = mask.expand(num_filters, num_channels, kernel_height, kernel_width).contiguous().cuda()
 
     assert mask.shape == conv_p.shape
     return mask
@@ -177,7 +177,7 @@ def run_forward_backward(model, optimizer, dummy_input):
     criterion = torch.nn.CrossEntropyLoss().cuda()
     model.train()
     output = model(dummy_input)
-    target = torch.LongTensor(1).random_(2)
+    target = torch.LongTensor(1).random_(2).cuda()
     loss = criterion(output, target)
     optimizer.zero_grad()
     loss.backward()
@@ -233,7 +233,7 @@ def arbitrary_channel_pruning(config, channels_to_remove):
         assert bn1.bias.size(0) == cnt_nnz_channels
         assert bn1.weight.size(0) == cnt_nnz_channels
 
-    dummy_input = torch.randn(1, 3, 32, 32)
+    dummy_input = torch.randn(1, 3, 32, 32).cuda()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9, weight_decay=0.1)
     run_forward_backward(model, optimizer, dummy_input)
 
@@ -278,7 +278,7 @@ def test_conv_fc_interface(model=None, zeros_mask_dict=None):
     ratio_to_prune = 0.1
     conv_name = "features.34"
     fc_name = "classifier.0"
-    dummy_input = torch.randn(1, 3, 224, 224)
+    dummy_input = torch.randn(1, 3, 224, 224).cuda()
 
     if model is None or zeros_mask_dict is None:
         model, zeros_mask_dict = common.setup_test(arch, dataset)


### PR DESCRIPTION
Remove the complicated logic trying to handle data-parallel models as

serially-processed models, and vice versa.

*Function distiller.utils.make_non_parallel_copy() does the heavy lifting of
replacing  all instances of nn.DataParallel in a model with instances of
DoNothingModuleWrapper.
The DoNothingModuleWrapper wrapper does nothing but forward to the
wrapped module.  This is a trick we use to transform a data-parallel model
to a serial-processed model.

*SummaryGraph uses a copy of the model after the model is processed by
distiller.make_non_parallel_copy() which renders the model non-data-parallel.

*The same goes for model_performance_summary()

*Model inputs are explicitly placed on the Cuda device, since now all models are
Executed on the CPU.  Previously, if a model was not created using
nn.DataParallel, then the model was not explicitly placed on the Cuda device.

*The logic in distiller.CompressionScheduler that attempted to load a
model parallel model and process it serially, or load a serial model and
process it data-parallel, was removed.  This removes a lot of fuzziness and makes
the code more robust: we do not needlessly try to be heroes.