### PR TITLE
Generalize the loss value returned from before_backward_pass callbacks

### DIFF
--- a/distiller/policy.py
+++ b/distiller/policy.py
@@ -21,11 +21,17 @@
 - LRPolicy: learning-rate decay scheduling
 """
 import torch
+from collections import namedtuple
 
 import logging
 msglogger = logging.getLogger()
 
-__all__ = ['PruningPolicy', 'RegularizationPolicy', 'QuantizationPolicy', 'LRPolicy', 'ScheduledTrainingPolicy']
+__all__ = ['PruningPolicy', 'RegularizationPolicy', 'QuantizationPolicy', 'LRPolicy', 'ScheduledTrainingPolicy',
+           'PolicyLoss', 'LossComponent']
+
+PolicyLoss = namedtuple('PolicyLoss', ['overall_loss', 'loss_components'])
+LossComponent = namedtuple('LossComponent', ['name', 'value'])
+
 
 class ScheduledTrainingPolicy(object):
     """ Base class for all scheduled training policies.
@@ -40,14 +46,20 @@ class ScheduledTrainingPolicy(object):
         """A new epcoh is about to begin"""
         pass
 
-    def on_minibatch_begin(self, model, epoch, minibatch_id, minibatches_per_epoch, zeros_mask_dict, optimizr=None):
+    def on_minibatch_begin(self, model, epoch, minibatch_id, minibatches_per_epoch, zeros_mask_dict, optimizer=None):
         """The forward-pass of a new mini-batch is about to begin"""
         pass
 
-    def before_backward_pass(self, model, epoch, minibatch_id, minibatches_per_epoch, loss,
-                             regularizer_loss, zeros_mask_dict, optimizer=None):
+    def before_backward_pass(self, model, epoch, minibatch_id, minibatches_per_epoch, loss, zeros_mask_dict,
+                             optimizer=None):
         """The mini-batch training pass has completed the forward-pass,
         and is about to begin the backward pass.
+
+        This callback receives a 'loss' argument. The callback should not modify this argument, but it can
+        optionally return an instance of 'PolicyLoss' which will be used in place of `loss'.
+
+        Note: The 'loss_components' parameter within 'PolicyLoss' should contain any new, individual loss components
+              the callback contributed to 'overall_loss'. It should not contain the incoming 'loss' argument.
         """
         pass
 
@@ -81,7 +93,7 @@ class PruningPolicy(ScheduledTrainingPolicy):
         for param_name, param in model.named_parameters():
             self.pruner.set_param_mask(param, param_name, zeros_mask_dict, meta)
 
-    def on_minibatch_begin(self, model, epoch, minibatch_id, minibatches_per_epoch, zeros_mask_dict, optimizer):
+    def on_minibatch_begin(self, model, epoch, minibatch_id, minibatches_per_epoch, zeros_mask_dict, optimizer=None):
         for param_name, param in model.named_parameters():
             zeros_mask_dict[param_name].apply_mask(param)
 
@@ -100,9 +112,15 @@ class RegularizationPolicy(ScheduledTrainingPolicy):
         self.is_last_epoch = meta['current_epoch'] == (meta['ending_epoch'] - 1)
 
     def before_backward_pass(self, model, epoch, minibatch_id, minibatches_per_epoch, loss,
-                             regularizer_loss, zeros_mask_dict, optimizer=None):
+                             zeros_mask_dict, optimizer=None):
+        regularizer_loss = torch.tensor(0, dtype=torch.float, device=loss.device)
+
         for param_name, param in model.named_parameters():
             self.regularizer.loss(param, param_name, regularizer_loss, zeros_mask_dict)
+
+        policy_loss = PolicyLoss(loss + regularizer_loss,
+                                 [LossComponent(self.regularizer.__class__.__name__ + '_loss', regularizer_loss)])
+        return policy_loss
 
     def on_minibatch_end(self, model, epoch, minibatch_id, minibatches_per_epoch, zeros_mask_dict, optimizer):
         if self.regularizer.threshold_criteria is None:

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -144,9 +144,12 @@ parser.add_argument('--validation-size', '--vs', type=float_range, default=0.1,
                     help='Portion of training dataset to set aside for validation')
 parser.add_argument('--adc', dest='ADC', action='store_true', help='temp HACK')
 parser.add_argument('--adc-params', dest='ADC_params', default=None, help='temp HACK')
-parser.add_argument('--confusion', dest='display_confusion', default=False, action='store_true', help='Display the confusion matrix')
-parser.add_argument('--earlyexit_lossweights', type=float, nargs='*', dest='earlyexit_lossweights', default=None, help='List of loss weights for early exits (e.g. --lossweights 0.1 0.3)')
-parser.add_argument('--earlyexit_thresholds', type=float, nargs='*', dest='earlyexit_thresholds', default=None, help='List of EarlyExit thresholds (e.g. --earlyexit 1.2 0.9)')
+parser.add_argument('--confusion', dest='display_confusion', default=False, action='store_true',
+                    help='Display the confusion matrix')
+parser.add_argument('--earlyexit_lossweights', type=float, nargs='*', dest='earlyexit_lossweights', default=None,
+                    help='List of loss weights for early exits (e.g. --lossweights 0.1 0.3)')
+parser.add_argument('--earlyexit_thresholds', type=float, nargs='*', dest='earlyexit_thresholds', default=None,
+                    help='List of EarlyExit thresholds (e.g. --earlyexit 1.2 0.9)')
 
 
 def check_pytorch_version():
@@ -302,7 +305,8 @@ def main():
                  OrderedDict([('Loss', vloss),
                               ('Top1', top1),
                               ('Top5', top5)]))
-        distiller.log_training_progress(stats, None, epoch, steps_completed=0, total_steps=1, log_freq=1, loggers=[tflogger])
+        distiller.log_training_progress(stats, None, epoch, steps_completed=0, total_steps=1, log_freq=1,
+                                        loggers=[tflogger])
 
         if compression_scheduler:
             compression_scheduler.on_epoch_end(epoch, optimizer)
@@ -320,19 +324,22 @@ def main():
     test(test_loader, model, criterion, [pylogger], args=args)
 
 
+OVERALL_LOSS_KEY = 'Overall Loss'
+OBJECTIVE_LOSS_KEY = 'Objective Loss'
+
+
 def train(train_loader, model, criterion, optimizer, epoch,
           compression_scheduler, loggers, args):
     """Training loop for one epoch."""
-    losses = {'objective_loss':   tnt.AverageValueMeter(),
-              'regularizer_loss': tnt.AverageValueMeter()}
-    if compression_scheduler is None:
-        # Initialize the regularizer loss to zero
-        losses['regularizer_loss'].add(0)
+    losses = OrderedDict([(OVERALL_LOSS_KEY, tnt.AverageValueMeter()),
+                          (OBJECTIVE_LOSS_KEY, tnt.AverageValueMeter())])
 
     classerr = tnt.ClassErrorMeter(accuracy=True, topk=(1, 5))
     batch_time = tnt.AverageValueMeter()
     data_time = tnt.AverageValueMeter()
-    # For Early Exit, we define statistics for each exit - so exiterrors is analogous to classerr for the non-Early Exit case
+
+    # For Early Exit, we define statistics for each exit
+    # So exiterrors is analogous to classerr for the non-Early Exit case
     if args.earlyexit_lossweights:
         args.exiterrors = []
         for exitnum in range(args.num_exits):
@@ -368,13 +375,19 @@ def train(train_loader, model, criterion, optimizer, epoch,
             # Measure accuracy and record loss
             loss = earlyexit_loss(output, target_var, criterion, args)
 
-        losses['objective_loss'].add(loss.item())
+        losses[OBJECTIVE_LOSS_KEY].add(loss.item())
 
         if compression_scheduler:
-            # Before running the backward phase, we add any regularization loss computed by the scheduler
-            regularizer_loss = compression_scheduler.before_backward_pass(epoch, train_step, steps_per_epoch, loss, optimizer)
-            loss += regularizer_loss
-            losses['regularizer_loss'].add(regularizer_loss.item())
+            # Before running the backward phase, we allow the scheduler to modify the loss
+            # (e.g. add regularization loss)
+            agg_loss = compression_scheduler.before_backward_pass(epoch, train_step, steps_per_epoch, loss,
+                                                                  optimizer=optimizer, return_loss_components=True)
+            loss = agg_loss.overall_loss
+            losses[OVERALL_LOSS_KEY].add(loss.item())
+            for lc in agg_loss.loss_components:
+                if lc.name not in losses:
+                    losses[lc.name] = tnt.AverageValueMeter()
+                losses[lc.name].add(lc.value.item())
 
         # Compute the gradient and do SGD step
         optimizer.zero_grad()
@@ -389,28 +402,23 @@ def train(train_loader, model, criterion, optimizer, epoch,
 
         if steps_completed % args.print_freq == 0:
             # Log some statistics
-            lr = optimizer.param_groups[0]['lr']
+            errs = OrderedDict()
             if not args.earlyexit_lossweights:
-                stats = ('Peformance/Training/',
-                         OrderedDict([
-                             ('Loss', losses['objective_loss'].mean),
-                             ('Reg Loss', losses['regularizer_loss'].mean),
-                             ('Top1', classerr.value(1)),
-                             ('Top5', classerr.value(5)),
-                             ('LR', lr),
-                             ('Time', batch_time.mean)]))
+                errs['Top1'] = classerr.value(1)
+                errs['Top5'] = classerr.value(5)
             else:
                 # for Early Exit case, the Top1 and Top5 stats are computed for each exit.
-                stats_dict = OrderedDict()
-                stats_dict['Objective Loss'] = losses['objective_loss'].mean
                 for exitnum in range(args.num_exits):
-                    t1 = 'Top1_exit' + str(exitnum)
-                    t5 = 'Top5_exit' + str(exitnum)
-                    stats_dict[t1] = args.exiterrors[exitnum].value(1)
-                    stats_dict[t5] = args.exiterrors[exitnum].value(5)
-                stats_dict['LR'] = lr
-                stats_dict['Time'] = batch_time.mean
-                stats = ('Peformance/Training/', stats_dict)
+                    errs['Top1_exit' + str(exitnum)] = args.exiterrors[exitnum].value(1)
+                    errs['Top5_exit' + str(exitnum)] = args.exiterrors[exitnum].value(5)
+
+            stats_dict = OrderedDict()
+            for loss_name, meter in losses.items():
+                stats_dict[loss_name] = meter.mean
+            stats_dict.update(errs)
+            stats_dict['LR'] = optimizer.param_groups[0]['lr']
+            stats_dict['Time'] = batch_time.mean
+            stats = ('Peformance/Training/', stats_dict)
 
             params = model.named_parameters() if args.log_params_histograms else None
             distiller.log_training_progress(stats,
@@ -520,7 +528,7 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1):
             msglogger.info('==> Confusion:\n%s', str(confusion.value()))
         return classerr.value(1), classerr.value(5), losses['objective_loss'].mean
     else:
-        #print some interesting summary stats for number of data points that could exit early
+        # Print some interesting summary stats for number of data points that could exit early
         top1k_stats = [0] * args.num_exits
         top5k_stats = [0] * args.num_exits
         losses_exits_stats = [0] * args.num_exits
@@ -534,8 +542,8 @@ def _validate(data_loader, model, criterion, loggers, args, epoch=-1):
                 losses_exits_stats[exitnum] += args.losses_exits[exitnum].mean
         for exitnum in range(args.num_exits):
             if args.exit_taken[exitnum]:
-                msglogger.info("Percent Early Exit %d: %.3f", exitnum, (args.exit_taken[exitnum]*100.0) / sum_exit_stats)
-
+                msglogger.info("Percent Early Exit %d: %.3f", exitnum,
+                               (args.exit_taken[exitnum]*100.0) / sum_exit_stats)
 
         return top1k_stats[args.num_exits-1], top5k_stats[args.num_exits-1], losses_exits_stats[args.num_exits-1]
 
@@ -563,6 +571,7 @@ def get_inference_var(tensor):
         return torch.autograd.Variable(tensor)
     return torch.autograd.Variable(tensor, volatile=True)
 
+
 def earlyexit_loss(output, target_var, criterion, args):
     loss = 0
     sum_lossweights = 0
@@ -574,6 +583,7 @@ def earlyexit_loss(output, target_var, criterion, args):
     loss += (1.0 - sum_lossweights) * criterion(output[args.num_exits-1], target_var)
     args.exiterrors[args.num_exits-1].add(output[args.num_exits-1].data, target_var)
     return loss
+
 
 def earlyexit_validate_loss(output, target_var, criterion, args):
     for exitnum in range(args.num_exits):
@@ -594,7 +604,8 @@ def earlyexit_validate_loss(output, target_var, criterion, args):
                 args.exit_taken[exitnum] += 1
             else:
                 # skip the early exits and include results from end of net
-                args.exiterrors[args.num_exits-1].add(torch.tensor(np.array(output[args.num_exits-1].data[batchnum], ndmin=2)),
+                args.exiterrors[args.num_exits-1].add(torch.tensor(np.array(output[args.num_exits-1].data[batchnum],
+                                                                            ndmin=2)),
                         torch.full([1], target_var[batchnum], dtype=torch.long))
                 args.exit_taken[args.num_exits-1] += 1
 

--- a/examples/word_language_model/main.py
+++ b/examples/word_language_model/main.py
@@ -236,10 +236,11 @@ def train(epoch, optimizer, compression_scheduler=None):
         loss = criterion(output.view(-1, ntokens), targets)
 
         if compression_scheduler:
-            # Before running the backward phase, we add any regularization loss computed by the scheduler
-            regularizer_loss = compression_scheduler.before_backward_pass(epoch, minibatch_id=batch,
-                                                                          minibatches_per_epoch=steps_per_epoch, loss=loss)
-            loss += regularizer_loss
+            # Before running the backward phase, we allow the scheduler to modify the loss
+            # (e.g. add regularization loss)
+            loss = compression_scheduler.before_backward_pass(epoch, minibatch_id=batch,
+                                                              minibatches_per_epoch=steps_per_epoch, loss=loss,
+                                                              return_loss_components=False)
 
         optimizer.zero_grad()
         loss.backward()

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+import os
+import sys
+import torch.nn as nn
+from copy import deepcopy
+import pytest
+
+module_path = os.path.abspath(os.path.join('..'))
+if module_path not in sys.path:
+    sys.path.append(module_path)
+from distiller import ScheduledTrainingPolicy, CompressionScheduler
+from distiller.policy import PolicyLoss, LossComponent
+
+
+class DummyPolicy(ScheduledTrainingPolicy):
+    def __init__(self, idx):
+        super(DummyPolicy, self).__init__()
+        self.loss_val = torch.randint(0, 10000, (1,))
+        self.idx = idx
+
+    def before_backward_pass(self, model, epoch, minibatch_id, minibatches_per_epoch, loss,
+                             zeros_mask_dict, optimizer=None):
+        return PolicyLoss(loss + self.loss_val, [LossComponent('Dummy Loss ' + str(self.idx), self.loss_val)])
+
+
+@pytest.mark.parametrize("check_loss_components", [False, True])
+def test_multiple_policies_loss(check_loss_components):
+    model = nn.Module()
+    scheduler = CompressionScheduler(model, device=torch.device('cpu'))
+    num_policies = 3
+    expected_overall_loss = 0
+    expected_policy_losses = []
+    for i in range(num_policies):
+        policy = DummyPolicy(i)
+        expected_overall_loss += policy.loss_val
+        expected_policy_losses.append(policy.loss_val)
+        scheduler.add_policy(policy, epochs=[0])
+
+    main_loss = torch.randint(0, 10000, (1,))
+    expected_overall_loss += main_loss
+    main_loss_before = deepcopy(main_loss)
+
+    policies_loss = scheduler.before_backward_pass(0, 0, 1, main_loss, return_loss_components=check_loss_components)
+
+    assert main_loss_before == main_loss
+    if check_loss_components:
+        assert expected_overall_loss == policies_loss.overall_loss
+        for idx, lc in enumerate(policies_loss.loss_components):
+            assert lc.name == 'Dummy Loss ' + str(idx)
+            assert expected_policy_losses[idx] == lc.value.item()
+    else:
+        assert expected_overall_loss == policies_loss


### PR DESCRIPTION
* Instead of a single additive value (which so far represented only the
  regularizer loss), callbacks return a new overall loss
* Policy callbacks also return the individual loss components used to
  calculate the new overall loss.
* Add boolean flag to the Scheduler's callback so applications can choose
  if they want to get individual loss components, or just the new overall
  loss
* In compress_classifier.py, log the individual loss components
* Add test for the loss-from-callback flow