### PR TITLE
Bug fix: value of best_top1 stored in the checkpoint may be wrong

### DIFF
--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -399,13 +399,12 @@ def main():
         if compression_scheduler:
             compression_scheduler.on_epoch_end(epoch, optimizer)
 
-        # remember best top1 and save checkpoint
-        #sparsity = distiller.model_sparsity(model)
-        is_best = top1 > best_epochs[0].top1
-        if is_best:
+        # Update the list of top scores achieved so far, and save the checkpoint
+        is_best = top1 > best_epochs[-1].top1
+        if top1 > best_epochs[0].top1:
             best_epochs[0].epoch = epoch
             best_epochs[0].top1 = top1
-            #best_epoch.sparsity = sparsity
+            # Keep best_epochs sorted such that best_epochs[0] is the lowest top1 in the best_epochs list
             best_epochs = sorted(best_epochs, key=lambda score: score.top1)
         for score in reversed(best_epochs):
             if score.top1 > 0:

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -154,7 +154,7 @@ parser.add_argument('--num-best-scores', dest='num_best_scores', default=1, type
                     help='number of best scores to track and report (default: 1)')
 parser.add_argument('--load-serialized', dest='load_serialized', action='store_true', default=False,
                     help='Load a model without DataParallel wrapping it')
-                    
+
 quant_group = parser.add_argument_group('Arguments controlling quantization at evaluation time'
                                         '("post-training quantization)')
 quant_group.add_argument('--quantize-eval', '--qe', action='store_true',
@@ -411,7 +411,7 @@ def main():
             if score.top1 > 0:
                 msglogger.info('==> Best Top1: %.3f on Epoch: %d', score.top1, score.epoch)
         apputils.save_checkpoint(epoch, args.arch, model, optimizer, compression_scheduler,
-                                 best_epochs[0].top1, is_best, args.name, msglogger.logdir)
+                                 best_epochs[-1].top1, is_best, args.name, msglogger.logdir)
 
     # Finally run results on the test set
     test(test_loader, model, criterion, [pylogger], activations_collectors, args=args)


### PR DESCRIPTION
If you invoke compress_clasifier.py with --num-best-scores=n
with n>1, then the value of best_top1 stored in checkpoints is wrong.