### PR TITLE
Fix Issue 79

### DIFF
--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -83,7 +83,7 @@ class CompressionScheduler(object):
             masker = ParameterMasker(name)
             self.zeros_mask_dict[name] = masker
 
-    def add_policy(self, policy, epochs=None, starting_epoch=None, ending_epoch=None, frequency=None):
+    def add_policy(self, policy, epochs=None, starting_epoch=0, ending_epoch=1, frequency=1):
         """Add a new policy to the schedule.
 
         Args:

--- a/tests/full_flow_tests.py
+++ b/tests/full_flow_tests.py
@@ -95,6 +95,20 @@ def accuracy_checker(log, expected_top1, expected_top5):
     return compare_values('Top-5', expected_top5, float(tops[-1][1]))
 
 
+def collateral_checker(log, *collateral_list):
+    """Test that the test produced the expected collaterals.
+
+    A collateral_list is a list of tuples, where tuple elements are:
+        0: file name
+        1: expected file size
+    """
+    for collateral in collateral_list:
+        statinfo = os.stat(collateral[0])
+        if statinfo.st_size != collateral[1]:
+            return False
+    return True
+
+
 ###########
 # Test Configurations
 ###########
@@ -107,7 +121,10 @@ test_configs = [
                DS_CIFAR, accuracy_checker, [91.620, 99.630]),
     TestConfig('-a preact_resnet20_cifar --epochs 2 --compress {0}'.
                format(os.path.join('full_flow_tests', 'preact_resnet20_cifar_pact_test.yaml')),
-               DS_CIFAR, accuracy_checker, [48.290, 94.460])
+               DS_CIFAR, accuracy_checker, [48.290, 94.460]),
+    TestConfig('-a resnet20_cifar --resume {0} --sense=filter --sense-range 0 0.10 0.05'.
+               format(os.path.join(examples_root, 'ssl', 'checkpoints', 'checkpoint_trained_dense.pth.tar')),
+               DS_CIFAR, collateral_checker, [('sensitivity.csv', 3188), ('sensitivity.png', 96158)])
 ]
 
 


### PR DESCRIPTION
- Bug fix for issue #79
Change the default values so that the following scheduler meta-data keys
are always defined: 'starting_epoch', 'ending_epoch', 'frequency'

- compress_classifier.py: add a new command-line argument
Allow the specification, from the command line arguments,  of the range of
pruning levels scanned when doing sensitivity analysis

- Add regression test for issue #79