### PR TITLE
Fix assign_layer_fq_names

### DIFF
--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -72,8 +72,12 @@ def assign_layer_fq_names(container, name=None):
     """
     is_leaf = True
     for key, module in container._modules.items():
-        is_leaf = False
-        assign_layer_fq_names(module, ".".join([name, key]) if name is not None else key)
+        try:
+            assign_layer_fq_names(module, ".".join([name, key]) if name is not None else key)
+            is_leaf = False
+        except AttributeError:
+            if module is not None:
+                raise
     if is_leaf:
         container.distiller_name = name
 


### PR DESCRIPTION
Add support to models that contain named empty layers.
This solution suppresses such events, and the layer is ignored.

How to reproduce:
See the Resnet variants found on: https://github.com/Cadene/pretrained-models.pytorch
Specifically, the last FC layer