### PR TITLE
Bug fixed for evaluating thinning and linear quantized model and Low-precisions checkpoint saving

### DIFF
--- a/apputils/checkpoint.py
+++ b/apputils/checkpoint.py
@@ -66,6 +66,17 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
         checkpoint['thinning_recipes'] = model.thinning_recipes
     if hasattr(model, 'quantizer_metadata'):
         checkpoint['quantizer_metadata'] = model.quantizer_metadata
+        b_wts = 'bits_weights' if 'bits_weights' in model.quantizer_metadata['params'] else 'bits_parameters'
+        if  model.quantizer_metadata['params'][b_wts] <= 8:
+            msglogger.info("Storing low precision state_dict")
+            q_dict = {}
+            for k, v in model.state_dict().items():
+                q_dict[k] = v.clone().detach()
+                q_dict[k].type(torch.int8)
+                verify = q_dict[k].clone().detach()
+                verify.type(torch.float32)
+                assert verify.equal(v)
+            checkpoint['state_dict'] = q_dict
 
     torch.save(checkpoint, fullpath)
     if is_best:

--- a/apputils/checkpoint.py
+++ b/apputils/checkpoint.py
@@ -73,7 +73,7 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
             for k, v in model.state_dict().items():
                 if 'wrapped_module.weight' in k:
                     q_dict[k] = torch.CharTensor(v.cpu().data.numpy())
-                else: 
+                else:
                     q_dict[k] = v
             checkpoint['state_dict'] = q_dict
 

--- a/apputils/checkpoint.py
+++ b/apputils/checkpoint.py
@@ -69,13 +69,9 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
         b_wts = 'bits_weights' if 'bits_weights' in model.quantizer_metadata['params'] else 'bits_parameters'
         if  save_low_precision and model.quantizer_metadata['params'][b_wts] <= 8:
             msglogger.info("Storing low precision state_dict")
-            q_dict = {}
-            for k, v in model.state_dict().items():
+            for k, v in checkpoint['state_dict'].items():
                 if 'wrapped_module.weight' in k:
-                    q_dict[k] = torch.CharTensor(v.cpu().data.numpy())
-                else:
-                    q_dict[k] = v
-            checkpoint['state_dict'] = q_dict
+                    checkpoint['state_dict'] = v.char()
 
     torch.save(checkpoint, fullpath)
     if is_best:

--- a/apputils/checkpoint.py
+++ b/apputils/checkpoint.py
@@ -71,7 +71,7 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
             msglogger.info("Storing low precision state_dict")
             for k, v in checkpoint['state_dict'].items():
                 if 'wrapped_module.weight' in k:
-                    checkpoint['state_dict'] = v.char()
+                    checkpoint['state_dict'][k] = v.char()
 
     torch.save(checkpoint, fullpath)
     if is_best:

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -366,7 +366,7 @@ def main():
         return sensitivity_analysis(model, criterion, test_loader, pylogger, args, sensitivities)
 
     if args.evaluate:
-        return evaluate_model(model, criterion, test_loader, pylogger, activations_collectors, args)
+        return evaluate_model(model, criterion, test_loader, pylogger, activations_collectors, args, compression_scheduler)
 
     if args.compress:
         # The main use-case for this sample application is CNN compression. Compression
@@ -724,7 +724,7 @@ def earlyexit_validate_stats(args):
     msglogger.info("Totals for entire network with early exits: top1 = %.3f, top5 = %.3f", total_top1, total_top5)
     return(total_top1, total_top5, losses_exits_stats)
 
-def evaluate_model(model, criterion, test_loader, loggers, activations_collectors, args):
+def evaluate_model(model, criterion, test_loader, loggers, activations_collectors, args, scheduler=None):
     # This sample application can be invoked to evaluate the accuracy of your model on
     # the test dataset.
     # You can optionally quantize the model to 8-bit integer before evaluation.
@@ -746,7 +746,7 @@ def evaluate_model(model, criterion, test_loader, loggers, activations_collector
 
     if args.quantize_eval:
         checkpoint_name = 'quantized'
-        apputils.save_checkpoint(0, args.arch, model, optimizer=None, best_top1=top1,
+        apputils.save_checkpoint(0, args.arch, model, optimizer=None, best_top1=top1, scheduler=scheduler,
                                  name='_'.join([args.name, checkpoint_name]) if args.name else checkpoint_name,
                                  dir=msglogger.logdir,save_low_precision=args.low_precision)
 

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -140,6 +140,8 @@ parser.add_argument('--extras', default=None, type=str,
                     help='file with extra configuration information')
 parser.add_argument('--deterministic', '--det', action='store_true',
                     help='Ensure deterministic execution for re-producible results.')
+parser.add_argument('--low-precision', '--lowp', action='store_true',
+                    help='Save quantized state_dict into low precision data type.')
 parser.add_argument('--gpus', metavar='DEV_ID', default=None,
                     help='Comma-separated list of GPU device IDs to be used (default is to use all available devices)')
 parser.add_argument('--name', '-n', metavar='NAME', default=None, help='Experiment name')
@@ -746,7 +748,7 @@ def evaluate_model(model, criterion, test_loader, loggers, activations_collector
         checkpoint_name = 'quantized'
         apputils.save_checkpoint(0, args.arch, model, optimizer=None, best_top1=top1,
                                  name='_'.join([args.name, checkpoint_name]) if args.name else checkpoint_name,
-                                 dir=msglogger.logdir)
+                                 dir=msglogger.logdir,save_low_precision=args.low_precision)
 
 
 def summarize_model(model, dataset, which_summary):


### PR DESCRIPTION
Since the low precision quantization does not save the weight to correspond data type.
It may be helpful to check the reduction of model size directly. 

SymmetricLinearQuantizer override the FP32 weight to int value
But it can be saved by int8 to reduce storage space
and will automatically load to FP32 by load_state_dict 

A simple usage example 
```python3 compress_classifier.py -a resnet20_cifar ./cifar-10 --qe -e --lowp ```
can easily compare reduction of size with 
```python3 compress_classifier.py -a resnet20_cifar ./cifar-10 --qe -e ```
by check the disk size

Another issue is that doing quantize for thinning model in evaluate_model(--quantize):
Because compression_scheduler is not saved by apputil.save_checkpoint,
It can not apply thinning recipe when loading checkpoint
