### PR TITLE
Bug fixed for earlyexit

### DIFF
--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -151,9 +151,9 @@ parser.add_argument('--adc-params', dest='ADC_params', default=None, help='temp 
 parser.add_argument('--confusion', dest='display_confusion', default=False, action='store_true',
                     help='Display the confusion matrix')
 parser.add_argument('--earlyexit_lossweights', type=float, nargs='*', dest='earlyexit_lossweights', default=None,
-                    help='List of loss weights for early exits (e.g. --lossweights 0.1 0.3)')
+                    help='List of loss weights for early exits (e.g. --earlyexit_lossweights 0.1 0.3)')
 parser.add_argument('--earlyexit_thresholds', type=float, nargs='*', dest='earlyexit_thresholds', default=None,
-                    help='List of EarlyExit thresholds (e.g. --earlyexit 1.2 0.9)')
+                    help='List of EarlyExit thresholds (e.g. --earlyexit_thresholds 1.2 0.9)')
 parser.add_argument('--num-best-scores', dest='num_best_scores', default=1, type=int,
                     help='number of best scores to track and report (default: 1)')
 parser.add_argument('--load-serialized', dest='load_serialized', action='store_true', default=False,
@@ -309,7 +309,7 @@ def main():
     args.num_classes = 10 if args.dataset == 'cifar10' else 1000
 
     if args.earlyexit_thresholds:
-        args.num_exits = len(args.earlyexit_thresholds) + 1
+        args.num_exits = len(args.earlyexit_thresholds)
         args.loss_exits = [0] * args.num_exits
         args.losses_exits = []
         args.exiterrors = []


### PR DESCRIPTION
I found that the script reports errors when I train earlyexit networks due to the wrong number of exits.
`python3 compress_classifier.py --arch resnet20_cifar_earlyexit ../../../data.cifar10 -p 30 -j=1 --lr=0.01 --earlyexit_lossweights 0.1 0.3 --earlyexit_thresholds 1.2 0.9`

And I updated the examples of earlyexit arguments which were not consistent with descriptions.

