### PR TITLE
Block pruning

### DIFF
--- a/apputils/checkpoint.py
+++ b/apputils/checkpoint.py
@@ -50,7 +50,8 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
     filename = 'checkpoint.pth.tar' if name is None else name + '_checkpoint.pth.tar'
     fullpath = os.path.join(dir, filename)
     msglogger.info("Saving checkpoint to: %s" % fullpath)
-    filename_best = 'best.pth.tar' if name is None else name + '_best.pth.tar'
+    filename_best = '_'.join(map(str, filter(lambda x: x is not None,
+                    [name, 'best', 'top1', best_top1]))) + '.pth.rar'
     fullpath_best = os.path.join(dir, filename_best)
     checkpoint = {}
     checkpoint['epoch'] = epoch

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -82,12 +82,15 @@ class CompressionScheduler(object):
         for name, param in self.model.named_parameters():
             masker = ParameterMasker(name)
             self.zeros_mask_dict[name] = masker
+        self.global_policy_end_epoch = None
 
-    def add_policy(self, policy, epochs=None, starting_epoch=0, ending_epoch=1, frequency=1):
-        """Add a new policy to the schedule.
+    def add_policy(self, policy, epochs=None, starting_epoch=0, ending_epoch=1, frequency=1,
+                   assert_policy_completion=False):
+        """Add a new policy to the schedule and update global_policy_end_epoch.
 
         Args:
             epochs (list): A list, or range, of epochs in which to apply the policy
+            assert_policy_completion: boolean, update global_policy_end_epoch
         """
 
         if epochs is None:
@@ -103,6 +106,9 @@ class CompressionScheduler(object):
         self.sched_metadata[policy] = {'starting_epoch': starting_epoch,
                                        'ending_epoch': ending_epoch,
                                        'frequency': frequency}
+        if assert_policy_completion:
+            self.global_policy_end_epoch = max(self.global_policy_end_epoch,
+                ending_epoch) if self.global_policy_end_epoch is not None else ending_epoch
 
     def on_epoch_begin(self, epoch, optimizer=None):
         if epoch in self.policies:


### PR DESCRIPTION
This patch tries to solve an issue I experienced when pruning pretrained models using distiller.
'best epochs' does not distinguish between top1 measurements taken before the model was pruned, or after, which results in bias toward the dense model measurements, and undermines the purpose of the study.
This patch implements the behavior **_I_** would expect to see.

Please note, I didn't test that patch thoroughly.