### PR TITLE
Fix best top1

### DIFF
--- a/apputils/checkpoint.py
+++ b/apputils/checkpoint.py
@@ -35,7 +35,7 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
 
     Args:
         epoch: current epoch
-        arch: name of the network arechitecture/topology
+        arch: name of the architecture/topology
         model: a pytorch model
         optimizer: the optimizer used in the training session
         scheduler: the CompressionScheduler instance used for training, if any
@@ -47,11 +47,6 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
     if not os.path.isdir(dir):
         raise IOError(ENOENT, 'Checkpoint directory does not exist at', os.path.abspath(dir))
 
-    filename = 'checkpoint.pth.tar' if name is None else name + '_checkpoint.pth.tar'
-    fullpath = os.path.join(dir, filename)
-    msglogger.info("Saving checkpoint to: %s" % fullpath)
-    filename_best = 'best.pth.tar' if name is None else name + '_best.pth.tar'
-    fullpath_best = os.path.join(dir, filename_best)
     checkpoint = {}
     checkpoint['epoch'] = epoch
     checkpoint['arch'] = arch
@@ -67,8 +62,14 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
     if hasattr(model, 'quantizer_metadata'):
         checkpoint['quantizer_metadata'] = model.quantizer_metadata
 
+    filename = 'checkpoint.pth.tar' if name is None else name + '_checkpoint.pth.tar'
+    fullpath = os.path.join(dir, filename)
+    filename_best = 'best_top1.pth.tar' if name is None else name + '_best_top1.pth.tar'
+    fullpath_best = os.path.join(dir, filename_best)
+    msglogger.info("Saving checkpoint to: %s" % fullpath)
     torch.save(checkpoint, fullpath)
     if is_best:
+        msglogger.info("Saving best checkpoint to: %s" % fullpath_best)
         shutil.copyfile(fullpath, fullpath_best)
 
 

--- a/distiller/config.py
+++ b/distiller/config.py
@@ -81,16 +81,13 @@ def dict_config(model, optimizer, sched_dict, scheduler=None):
                 instance_name, args = __policy_params(policy_def, 'regularizer')
                 assert instance_name in regularizers, "Regularizer {} was not defined in the list of regularizers".format(instance_name)
                 regularizer = regularizers[instance_name]
-                if args is None:
-                    policy = distiller.RegularizationPolicy(regularizer)
-                else:
-                    policy = distiller.RegularizationPolicy(regularizer, **args)
+                policy = distiller.RegularizationPolicy(regularizer, args)
 
             elif 'quantizer' in policy_def:
                 instance_name, args = __policy_params(policy_def, 'quantizer')
                 assert instance_name in quantizers, "Quantizer {} was not defined in the list of quantizers".format(instance_name)
                 quantizer = quantizers[instance_name]
-                policy = distiller.QuantizationPolicy(quantizer)
+                policy = distiller.QuantizationPolicy(quantizer, args)
 
             elif 'lr_scheduler' in policy_def:
                 # LR schedulers take an optimizer in their CTOR, so postpone handling until we're certain
@@ -102,7 +99,7 @@ def dict_config(model, optimizer, sched_dict, scheduler=None):
                 instance_name, args = __policy_params(policy_def, 'extension')
                 assert instance_name in extensions, "Extension {} was not defined in the list of extensions".format(instance_name)
                 extension = extensions[instance_name]
-                policy = extension
+                policy = distiller.ScheduledTrainingPolicy(extension, args)
 
             else:
                 raise ValueError("\nFATAL Parsing error while parsing the pruning schedule - unknown policy [%s]".format(policy_def))
@@ -131,11 +128,15 @@ def dict_config(model, optimizer, sched_dict, scheduler=None):
 
 def add_policy_to_scheduler(policy, policy_def, scheduler):
     if 'epochs' in policy_def:
-        scheduler.add_policy(policy, epochs=policy_def['epochs'])
+        epochs = policy_def['epochs']
     else:
-        scheduler.add_policy(policy, starting_epoch=policy_def['starting_epoch'],
-                            ending_epoch=policy_def['ending_epoch'],
-                            frequency=policy_def['frequency'])
+        epochs = range(
+            getattr(policy_def, 'starting_epoch', 0),
+            getattr(policy_def, 'ending_epoch', 0) + 1,
+            getattr(policy_def, 'frequency', 1),
+            )
+
+    scheduler.add_policy(policy, epochs)
 
 
 def file_config(model, optimizer, filename, scheduler=None):

--- a/distiller/knowledge_distillation.py
+++ b/distiller/knowledge_distillation.py
@@ -85,8 +85,10 @@ class KnowledgeDistillationPolicy(ScheduledTrainingPolicy):
 
     """
     def __init__(self, student_model, teacher_model, temperature=1.0,
-                 loss_weights=DistillationLossWeights(0.5, 0.5, 0)):
-        super(KnowledgeDistillationPolicy, self).__init__()
+                 loss_weights=DistillationLossWeights(0.5, 0.5, 0),
+                 defer_best_checkpoint=False):
+        super(KnowledgeDistillationPolicy, self).__init__(
+                defer_best_checkpoint=defer_best_checkpoint)
 
         if loss_weights.teacher != 0:
             raise NotImplementedError('Using teacher vs. labels loss is not supported yet, '

--- a/distiller/policy.py
+++ b/distiller/policy.py
@@ -99,18 +99,11 @@ class PruningPolicy(ScheduledTrainingPolicy):
         """
         super(PruningPolicy, self).__init__(classes, layers)
         self.pruner = pruner
-        self.levels = None
-        self.keep_mask = False
-        self.mini_batch_pruning_frequency = 0
-        self.mask_on_forward_only = False
-        self.use_double_copies = False
-        if pruner_args is not None:
-            if 'levels' in pruner_args:
-                self.levels = pruner_args['levels']
-            self.keep_mask = pruner_args.get('keep_mask', False)
-            self.mini_batch_pruning_frequency = pruner_args.get('mini_batch_pruning_frequency', 0)
-            self.mask_on_forward_only = pruner_args.get('mask_on_forward_only', False)
-            self.use_double_copies = pruner_args.get('use_double_copies', False)
+        self.levels = getattr(pruner_args, 'levels', None)
+        self.keep_mask = getattr(pruner_args, 'keep_mask', False)
+        self.mini_batch_pruning_frequency = getattr(pruner_args, 'mini_batch_pruning_frequency', 0)
+        self.mask_on_forward_only = getattr(pruner_args, 'mask_on_forward_only', False)
+        self.use_double_copies = getattr(pruner_args, 'use_double_copies', False)
         self.is_last_epoch = False
         self.mini_batch_id = 0          # The ID of the mini_batch within the present epoch
         self.global_mini_batch_id = 0   # The ID of the mini_batch within the present training session

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -83,16 +83,12 @@ class CompressionScheduler(object):
             masker = ParameterMasker(name)
             self.zeros_mask_dict[name] = masker
 
-    def add_policy(self, policy, epochs=None, starting_epoch=0, ending_epoch=1, frequency=1):
+    def add_policy(self, policy, epochs):
         """Add a new policy to the schedule.
 
         Args:
-            epochs (list): A list, or range, of epochs in which to apply the policy
+            epochs (range, iterable): epochs in which to apply the policy
         """
-
-        if epochs is None:
-            epochs = list(range(starting_epoch, ending_epoch, frequency))
-
         for epoch in epochs:
             if epoch not in self.policies:
                 self.policies[epoch] = [policy]
@@ -100,9 +96,13 @@ class CompressionScheduler(object):
                 self.policies[epoch].append(policy)
             assert len(self.policies[epoch]) > 0
 
+        # if isinstance(epochs, range), then getattr, otherwise assume iterable
+        starting_epoch = getattr(epochs, 'start', epochs[0])
+        ending_epoch = getattr(epochs, 'stop', max(epochs[-1], epochs[0]+1))
+        step_epoch = getattr(epochs, 'step', (ending_epoch - starting_epoch) // len(epochs))
         self.sched_metadata[policy] = {'starting_epoch': starting_epoch,
                                        'ending_epoch': ending_epoch,
-                                       'frequency': frequency}
+                                       'frequency': step_epoch}
 
     def on_epoch_begin(self, epoch, optimizer=None):
         if epoch in self.policies:

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -82,9 +82,10 @@ class CompressionScheduler(object):
         for name, param in self.model.named_parameters():
             masker = ParameterMasker(name)
             self.zeros_mask_dict[name] = masker
+        self.global_policy_end_epoch = None
 
     def add_policy(self, policy, epochs):
-        """Add a new policy to the schedule.
+        """Add a new policy to the schedule and update global_policy_end_epoch.
 
         Args:
             epochs (range, iterable): epochs in which to apply the policy
@@ -103,6 +104,10 @@ class CompressionScheduler(object):
         self.sched_metadata[policy] = {'starting_epoch': starting_epoch,
                                        'ending_epoch': ending_epoch,
                                        'frequency': step_epoch}
+
+        if policy.defer_best_checkpoint:
+            self.global_policy_end_epoch = (max(self.global_policy_end_epoch, ending_epoch)
+                if self.global_policy_end_epoch is not None else ending_epoch)
 
     def on_epoch_begin(self, epoch, optimizer=None):
         if epoch in self.policies:

--- a/distiller/thinning.py
+++ b/distiller/thinning.py
@@ -394,8 +394,8 @@ def create_thinning_recipe_filters(sgraph, model, zeros_mask_dict):
 
 class StructureRemover(ScheduledTrainingPolicy):
     """A policy which applies a network thinning function"""
-    def __init__(self, thinning_func_str, arch, dataset):
-        super(StructureRemover, self).__init__()
+    def __init__(self, thinning_func_str, arch, dataset, defer_best_checkpoint=False):
+        super(StructureRemover, self).__init__(defer_best_checkpoint=defer_best_checkpoint)
         self.thinning_func = globals()[thinning_func_str]
         self.arch = arch
         self.dataset = dataset

--- a/distiller/thinning.py
+++ b/distiller/thinning.py
@@ -395,6 +395,7 @@ def create_thinning_recipe_filters(sgraph, model, zeros_mask_dict):
 class StructureRemover(ScheduledTrainingPolicy):
     """A policy which applies a network thinning function"""
     def __init__(self, thinning_func_str, arch, dataset):
+        super(StructureRemover, self).__init__()
         self.thinning_func = globals()[thinning_func_str]
         self.arch = arch
         self.dataset = dataset

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -383,8 +383,7 @@ def main():
             teacher, _, _ = apputils.load_checkpoint(teacher, chkpt_file=args.kd_resume)
         dlw = distiller.DistillationLossWeights(args.kd_distill_wt, args.kd_student_wt, args.kd_teacher_wt)
         args.kd_policy = distiller.KnowledgeDistillationPolicy(model, teacher, args.kd_temp, dlw)
-        compression_scheduler.add_policy(args.kd_policy, starting_epoch=args.kd_start_epoch, ending_epoch=args.epochs,
-                                         frequency=1)
+        compression_scheduler.add_policy(args.kd_policy, range(args.kd_start_epoch, args.epochs, 1))
 
         msglogger.info('\nStudent-Teacher knowledge distillation enabled:')
         msglogger.info('\tTeacher Model: %s', args.kd_teacher)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -392,6 +392,11 @@ def main():
                        ' | '.join(['{:.2f}'.format(val) for val in dlw]))
         msglogger.info('\tStarting from Epoch: %s', args.kd_start_epoch)
 
+    if getattr(compression_scheduler, 'global_policy_end_epoch', None) is not None:
+        if compression_scheduler.global_policy_end_epoch >= (start_epoch + args.epochs):
+            msglogger.warning('scheduler requires at least {} epochs, but only {} are sanctioned'.format(
+                compression_scheduler.global_policy_end_epoch, args.epochs))
+
     for epoch in range(start_epoch, start_epoch + args.epochs):
         # This is the main training loop.
         msglogger.info('\n')
@@ -425,20 +430,22 @@ def main():
         if compression_scheduler:
             compression_scheduler.on_epoch_end(epoch, optimizer)
 
-        # Update the list of top scores achieved so far, and save the checkpoint
-        if top1 > 0:
-            best_epochs.append(distiller.MutableNamedTuple({'top1': top1, 'top5': top5, 'epoch': epoch}))
-        # Keep best_epochs sorted from best to worst
-        # Sort by top1 first, secondary sort by top5, and so forth
-        best_epochs.sort(key=operator.attrgetter('top1', 'top5', 'epoch'), reverse=True)
-        for score in best_epochs[:args.num_best_scores]:
-            msglogger.info('==> Best Top1: %.3f Top5: %.3f on epoch: %d',
-                           score.top1, score.top5, score.epoch)
+        if getattr(compression_scheduler, 'global_policy_end_epoch', None) is None or (
+            compression_scheduler.global_policy_end_epoch <= epoch):
+            # Update the list of top scores achieved since all policies have concluded
+            if top1 > 0:
+                best_epochs.append(distiller.MutableNamedTuple({'top1': top1, 'top5': top5, 'epoch': epoch}))
+            # Keep best_epochs sorted from best to worst
+            # Sort by top1 first, secondary sort by top5, and so forth
+            best_epochs.sort(key=operator.attrgetter('top1', 'top5', 'epoch'), reverse=True)
+            for score in best_epochs[:args.num_best_scores]:
+                msglogger.info('==> Best Top1: %.3f Top5: %.3f on epoch: %d',
+                               score.top1, score.top5, score.epoch)
 
         is_best = best_epochs and (epoch == best_epochs[0].epoch)
         apputils.save_checkpoint(epoch, args.arch, model, optimizer, compression_scheduler,
-                                 best_epochs[0].top1 if best_epochs else 0, is_best,
-                                 args.name, msglogger.logdir)
+                                 round(best_epochs[0].top1, 3) if best_epochs else None,
+                                 is_best, args.name, msglogger.logdir)
 
     # Finally run results on the test set
     test(test_loader, model, criterion, [pylogger], activations_collectors, args=args)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -53,6 +53,7 @@ models, or with the provided sample models:
 import math
 import argparse
 import time
+import operator
 import os
 import sys
 import random
@@ -269,8 +270,7 @@ def main():
     msglogger.debug("Distiller: %s", distiller.__version__)
 
     start_epoch = 0
-    best_epochs = [distiller.MutableNamedTuple({'epoch': 0, 'top1': 0, 'sparsity': 0})
-                   for i in range(args.num_best_scores)]
+    best_epochs = list()
 
     if args.deterministic:
         # Experiment reproducibility is sometimes important.  Pete Warden expounded about this
@@ -427,17 +427,19 @@ def main():
             compression_scheduler.on_epoch_end(epoch, optimizer)
 
         # Update the list of top scores achieved so far, and save the checkpoint
-        is_best = top1 > best_epochs[-1].top1
-        if top1 > best_epochs[0].top1:
-            best_epochs[0].epoch = epoch
-            best_epochs[0].top1 = top1
-            # Keep best_epochs sorted such that best_epochs[0] is the lowest top1 in the best_epochs list
-            best_epochs = sorted(best_epochs, key=lambda score: score.top1)
-        for score in reversed(best_epochs):
-            if score.top1 > 0:
-                msglogger.info('==> Best Top1: %.3f on Epoch: %d', score.top1, score.epoch)
+        if top1 > 0:
+            best_epochs.append(distiller.MutableNamedTuple({'top1': top1, 'top5': top5, 'epoch': epoch}))
+        # Keep best_epochs sorted from best to worst
+        # Sort by top1 first, secondary sort by top5, and so forth
+        best_epochs.sort(key=operator.attrgetter('top1', 'top5', 'epoch'), reverse=True)
+        for score in best_epochs[:args.num_best_scores]:
+            msglogger.info('==> Best Top1: %.3f Top5: %.3f on epoch: %d',
+                           score.top1, score.top5, score.epoch)
+
+        is_best = best_epochs and (epoch == best_epochs[0].epoch)
         apputils.save_checkpoint(epoch, args.arch, model, optimizer, compression_scheduler,
-                                 best_epochs[-1].top1, is_best, args.name, msglogger.logdir)
+                                 best_epochs[0].top1 if best_epochs else 0, is_best,
+                                 args.name, msglogger.logdir)
 
     # Finally run results on the test set
     test(test_loader, model, criterion, [pylogger], activations_collectors, args=args)


### PR DESCRIPTION
This patch tries to solve an issue I experienced when pruning pretrained models using distiller.
'best epochs' does not distinguish between top1 measurements taken before the model was pruned, or after, which results in bias toward the dense model measurements, and undermines the purpose of the study.
This patch implements the behavior I would expect to see.

Please note, I didn't test that patch thoroughly.