### PR TITLE
Refactor load_checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,16 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE.md](LIC
 
 ## Citation
 
+Research papers citing Distiller:
+-  Alexander Goncharenko, Andrey Denisov, Sergey Alyamkin, Evgeny Terentev.<br>
+   *"Fast Adjustable Threshold For Uniform Neural Network Quantization,"*<br>
+   [arXiv:1812.07872v2](https://arxiv.org/abs/1812.07872v2), 2018
+
+- Ritchie Zhao, Yuwei Hu, Jordan Dotzel, Christopher De Sa, Zhiru Zhang.<br>
+  *"Improving Neural Network Quantization without Retraining using Outlier Channel Splitting,"*<br>
+  [arXiv:1901.09504v2](https://arxiv.org/abs/1901.09504v20), 2019
+
+
 If you used Distiller for your work, please use the following citation:
 
 ```

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -17,6 +17,9 @@
 import logging
 import os
 import sys
+import tempfile
+
+import torch
 import pytest
 module_path = os.path.abspath(os.path.join('..'))
 if module_path not in sys.path:
@@ -33,6 +36,29 @@ def test_load():
     model, compression_scheduler, start_epoch = load_checkpoint(model, '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar')
     assert compression_scheduler is not None
     assert start_epoch == 180
+
+def test_load_state_dict():
+    # prepare lean checkpoint
+    state_dict_arrays = torch.load('../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar').get('state_dict')
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        torch.save({'state_dict': state_dict_arrays}, tmpfile.name)
+        model = create_model(False, 'cifar10', 'resnet20_cifar')
+        model, compression_scheduler, start_epoch = load_checkpoint(model, tmpfile.name)
+
+    assert len(list(model.named_modules())) >= len([x for x in state_dict_arrays if x.endswith('weight')]) > 0
+    assert compression_scheduler is None
+    assert start_epoch == 0
+
+def test_load_dumb_checkpoint():
+    # prepare lean checkpoint
+    state_dict_arrays = torch.load('../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar').get('state_dict')
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        torch.save(state_dict_arrays, tmpfile.name)
+        model = create_model(False, 'cifar10', 'resnet20_cifar')
+        with pytest.raises(ValueError):
+            model, compression_scheduler, start_epoch = load_checkpoint(model, tmpfile.name)
 
 def test_load_negative():
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
I have noticed recent commit on load_checkpoint, and since I have already refactored it recently, I propose my changes.

The original purpose was to support loading converted-checkpoints that do not contain the checkpoint structure that Distiller expects. However, this pull request is stripped from the converted-checkpoints support, because I don't think it should be merged into master.

[I've never tested this commit]