### PR TITLE
hotfix for broken block pruning

### DIFF
--- a/distiller/pruning/ranked_structures_pruner.py
+++ b/distiller/pruning/ranked_structures_pruner.py
@@ -119,7 +119,8 @@ class LpRankedStructureParameterPruner(RankedStructureParameterPruner):
             group_pruning_fn = partial(self.rank_and_prune_blocks, block_shape=self.block_shape)
 
         binary_map = group_pruning_fn(fraction_to_prune, param, param_name,
-                                      zeros_mask_dict, model, binary_map, self.magnitude_fn)
+                                      zeros_mask_dict, model, binary_map,
+                                      magnitude_fn=self.magnitude_fn)
         return binary_map
 
     @staticmethod


### PR DESCRIPTION
This patch corrects overlapping between
magnitude_fn and block_shape arguments during
block pruning.