### PR TITLE
Resume optimizer

### DIFF
--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -164,8 +164,9 @@ def main():
     # We can optionally resume from a checkpoint
     optimizer = None
     if args.resume:
-        # initiate SGD with dummy lr
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
+        if not args.reset_optimizer:
+            # initiate SGD with dummy lr
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
             model, args.resume, optimizer=optimizer)
         model.to(args.device)
@@ -236,7 +237,7 @@ def main():
         # The main use-case for this sample application is CNN compression. Compression
         # requires a compression schedule configuration file in YAML.
         compression_scheduler = distiller.file_config(model, optimizer, args.compress, compression_scheduler,
-            (start_epoch-1) if args.resume else None)
+            (start_epoch-1) if (args.resume and not args.reset_optimizer) else None)
         # Model is re-transferred to GPU in case parameters were added (e.g. PACTQuantizer)
         model.to(args.device)
     elif compression_scheduler is None:

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -163,12 +163,12 @@ def main():
 
     # We can optionally resume from a checkpoint
     optimizer = None
-    if args.resume:
-        if not args.reset_optimizer:
+    if args.resume or args.load_state_dict:
+        if args.resume and not args.reset_optimizer:
             # initiate SGD with dummy lr
             optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
-            model, args.resume, optimizer=optimizer)
+            model, args.resume or args.load_state_dict, optimizer=optimizer)
         model.to(args.device)
 
     # Define loss function (criterion) and optimizer

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -185,7 +185,7 @@ def main():
             ]
         if user_optim_args:
             msglogger.warning('{} optimizer arguments are ignored.'.format(user_optim_args))
-            msglogger.info('setting optimizer arguments when optimizer is resumed'
+            msglogger.info('setting optimizer arguments when optimizer is resumed '
                 'from checkpoint is forbidden.')
     else:
         optimizer = torch.optim.SGD(model.parameters(), lr=args.lr,

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -48,6 +48,8 @@ def get_parser():
                     metavar='M', help='momentum')
     optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
                     metavar='W', help='weight decay (default: 1e-4)')
+    parser.add_argument('--reset-optimizer', '--reset-lr', action='store_true',
+                        help='Flag to override optimizer if resumed from checkpoint')
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -40,12 +40,15 @@ def get_parser():
                         help='number of total epochs to run')
     parser.add_argument('-b', '--batch-size', default=256, type=int,
                         metavar='N', help='mini-batch size (default: 256)')
-    parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
-                        metavar='LR', help='initial learning rate')
-    parser.add_argument('--momentum', default=0.9, type=float, metavar='M',
-                        help='momentum')
-    parser.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
-                        metavar='W', help='weight decay (default: 1e-4)')
+
+    optimizer_args = parser.add_argument_group('optimizer_arguments')
+    optimizer_args.add_argument('--lr', '--learning-rate', default=0.1,
+                    type=float, metavar='LR', help='initial learning rate')
+    optimizer_args.add_argument('--momentum', default=0.9, type=float,
+                    metavar='M', help='momentum')
+    optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
+                    metavar='W', help='weight decay (default: 1e-4)')
+
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
     parser.add_argument('--resume', default='', type=str, metavar='PATH',

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -53,8 +53,13 @@ def get_parser():
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
-    parser.add_argument('--resume', default='', type=str, metavar='PATH',
+
+    load_checkpoint_group = parser.add_mutually_exclusive_group()
+    load_checkpoint_group.add_argument('--resume', default='', type=str, metavar='PATH',
                         help='path to latest checkpoint (default: none)')
+    load_checkpoint_group.add_argument('--load-state-dict', default='', type=str, metavar='PATH',
+                        help='load only state dict field from checkpoint at given path')
+
     parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                         help='evaluate model on validation set')
     parser.add_argument('--pretrained', dest='pretrained', action='store_true',

--- a/tests/full_flow_tests/steplr_training_resnet20_cifar.yaml
+++ b/tests/full_flow_tests/steplr_training_resnet20_cifar.yaml
@@ -1,0 +1,14 @@
+# python3 compress_classifier.py  --lr=0.1 --arch=resnet20_cifar ../../../data.cifar10 --compress=../../tests/full_flow_tests/steplr_training_resnet20_cifar.yaml
+
+lr_schedulers:
+  training_lr:
+    class: StepLR
+    step_size: 1
+    gamma: 0.10
+
+policies:
+    - lr_scheduler:
+        instance_name: training_lr
+      starting_epoch: 0
+      ending_epoch: 10
+      frequency: 1

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -59,7 +59,7 @@ def test_load():
     assert start_epoch == 180
 
 
-def test_load_state_dict():
+def test_load_state_dict_implicit():
     # prepare lean checkpoint
     state_dict_arrays = torch.load('../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar').get('state_dict')
 
@@ -69,6 +69,36 @@ def test_load_state_dict():
         model, compression_scheduler, optimizer, start_epoch = load_checkpoint(model, tmpfile.name)
 
     assert len(list(model.named_modules())) >= len([x for x in state_dict_arrays if x.endswith('weight')]) > 0
+    assert compression_scheduler is None
+    assert optimizer is None
+    assert start_epoch == 0
+
+
+def test_load_lean_checkpoint_1():
+    # prepare lean checkpoint
+    state_dict_arrays = torch.load('../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar').get('state_dict')
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        torch.save({'state_dict': state_dict_arrays}, tmpfile.name)
+        model = create_model(False, 'cifar10', 'resnet20_cifar')
+        model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
+            model, tmpfile.name, torch.optim.SGD(model.parameters(), lr=0.36787944117),
+            lean_checkpoint=True)
+
+    assert compression_scheduler is None
+    assert optimizer is None
+    assert start_epoch == 0
+
+
+def test_load_lean_checkpoint_2():
+    checkpoint_filename = '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar'
+
+    model = create_model(False, 'cifar10', 'resnet20_cifar', 0)
+    model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
+        model, checkpoint_filename,
+        torch.optim.SGD(model.parameters(), lr=0.36787944117),
+        lean_checkpoint=True)
+
     assert compression_scheduler is None
     assert optimizer is None
     assert start_epoch == 0
@@ -91,6 +121,7 @@ def test_load_negative():
         model, compression_scheduler, optimizer, start_epoch = load_checkpoint(model,
             'THIS_IS_AN_ERROR/checkpoint_trained_dense.pth.tar')
 
+
 def test_load_gpu_model_on_cpu():
     # Issue #148
     CPU_DEVICE_ID = -1
@@ -103,6 +134,19 @@ def test_load_gpu_model_on_cpu():
     assert compression_scheduler is not None
     assert optimizer is None
     assert start_epoch == 180
+    assert distiller.model_device(model) == 'cpu'
+
+
+def test_load_gpu_model_on_cpu_lean_checkpoint():
+    CPU_DEVICE_ID = -1
+    checkpoint_filename = '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar'
+
+    model = create_model(False, 'cifar10', 'resnet20_cifar', device_ids=CPU_DEVICE_ID)
+    model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
+        model, checkpoint_filename, lean_checkpoint=True)
+
+    assert compression_scheduler is None
+    assert optimizer is None
     assert distiller.model_device(model) == 'cpu'
 
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -296,7 +296,7 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
     conv2 = common.find_module_by_name(model_2, pair[1])
     assert conv2 is not None
     with pytest.raises(KeyError):
-        model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+        model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     compression_scheduler = distiller.CompressionScheduler(model)
     hasattr(model, 'thinning_recipes')
 
@@ -304,13 +304,13 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
 
     # (2)
     save_checkpoint(epoch=0, arch=config.arch, model=model, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done")
 
     # (3)
     save_checkpoint(epoch=0, arch=config.arch, model=model_2, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done 2")
 


### PR DESCRIPTION
This fixes long-standing bug in distiller with resuming from checkpoint.
Before this patch, the optimizer field in the checkpoint was ignored.

Although it corrects an erroneous behavior of the 'resume' flag, it _is_ a behavioral change of dominant functionality.

**A few thoughts before merging into master:**
* Documentation: This patch does not contain required changes to Distiller online documentation.
* Insufficient tests: None of current tests caught that bug, nor I address this matter in my patch.
I tested it briefly with the attached steplr lr_sched recipe, and enjoyed using it, but don't trust me on this - test for yourself. I have no idea how it plays with quantization, gpu<-->cpu transitions, or non-sgd optimizers.
* examples change: In the patch I added a flag that effectively reverts to the old incorrect behavior, but I didn't revise the examples in distiller.
1. I assume there's no example-file or notebook in Distiller that intentionally tries to take advantage of this bug.
2. with post-training pruning in mind - when one resumes local distiller checkpoint in order to prune it, it contains the old optimizer, and therefore what he probably expects is old behavior. This can be achieved with the 'reset-lr'/'reset-optimizer' flag. Using '--pretrained' without resume is not affected.

Please review, validate, test, and then merge with caution.