### PR TITLE
Resume training steps

### DIFF
--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -36,7 +36,7 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
 
     Args:
         epoch: current epoch
-        arch: name of the network arechitecture/topology
+        arch: name of the architecture/topology
         model: a pytorch model
         optimizer: the optimizer used in the training session
         scheduler: the CompressionScheduler instance used for training, if any
@@ -48,11 +48,6 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
     if not os.path.isdir(dir):
         raise IOError(ENOENT, 'Checkpoint directory does not exist at', os.path.abspath(dir))
 
-    filename = 'checkpoint.pth.tar' if name is None else name + '_checkpoint.pth.tar'
-    fullpath = os.path.join(dir, filename)
-    msglogger.info("Saving checkpoint to: %s" % fullpath)
-    filename_best = 'best.pth.tar' if name is None else name + '_best.pth.tar'
-    fullpath_best = os.path.join(dir, filename_best)
     checkpoint = {}
     checkpoint['epoch'] = epoch
     checkpoint['arch'] = arch
@@ -68,8 +63,14 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
     if hasattr(model, 'quantizer_metadata'):
         checkpoint['quantizer_metadata'] = model.quantizer_metadata
 
+    filename = 'checkpoint.pth.tar' if name is None else name + '_checkpoint.pth.tar'
+    fullpath = os.path.join(dir, filename)
+    filename_best = 'best_top1.pth.tar' if name is None else name + '_best_top1.pth.tar'
+    fullpath_best = os.path.join(dir, filename_best)
+    msglogger.info("Saving checkpoint to: %s" % fullpath)
     torch.save(checkpoint, fullpath)
     if is_best:
+        msglogger.info("Saving best checkpoint to: %s" % fullpath_best)
         shutil.copyfile(fullpath, fullpath_best)
 
 

--- a/distiller/config.py
+++ b/distiller/config.py
@@ -81,16 +81,13 @@ def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None
                 instance_name, args = __policy_params(policy_def, 'regularizer')
                 assert instance_name in regularizers, "Regularizer {} was not defined in the list of regularizers".format(instance_name)
                 regularizer = regularizers[instance_name]
-                if args is None:
-                    policy = distiller.RegularizationPolicy(regularizer)
-                else:
-                    policy = distiller.RegularizationPolicy(regularizer, **args)
+                policy = distiller.RegularizationPolicy(regularizer, args)
 
             elif 'quantizer' in policy_def:
                 instance_name, args = __policy_params(policy_def, 'quantizer')
                 assert instance_name in quantizers, "Quantizer {} was not defined in the list of quantizers".format(instance_name)
                 quantizer = quantizers[instance_name]
-                policy = distiller.QuantizationPolicy(quantizer)
+                policy = distiller.QuantizationPolicy(quantizer, args)
 
             elif 'lr_scheduler' in policy_def:
                 # LR schedulers take an optimizer in their CTOR, so postpone handling until we're certain
@@ -102,7 +99,7 @@ def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None
                 instance_name, args = __policy_params(policy_def, 'extension')
                 assert instance_name in extensions, "Extension {} was not defined in the list of extensions".format(instance_name)
                 extension = extensions[instance_name]
-                policy = extension
+                policy = distiller.ScheduledTrainingPolicy(extension, args)
 
             else:
                 raise ValueError("\nFATAL Parsing error while parsing the pruning schedule - unknown policy [%s]".format(policy_def))
@@ -131,12 +128,16 @@ def dict_config(model, optimizer, sched_dict, scheduler=None, resumed_epoch=None
 
 
 def add_policy_to_scheduler(policy, policy_def, scheduler):
-    if 'epochs' in policy_def:
-        scheduler.add_policy(policy, epochs=policy_def['epochs'])
-    else:
-        scheduler.add_policy(policy, starting_epoch=policy_def['starting_epoch'],
-                            ending_epoch=policy_def['ending_epoch'],
-                            frequency=policy_def['frequency'])
+    try:
+        epochs = policy_def['epochs']
+    except KeyError:
+        epochs = range(
+            policy_def.get('starting_epoch', 0),
+            policy_def.get('ending_epoch', 1),
+            policy_def.get('frequency', 1),
+            )
+
+    scheduler.add_policy(policy, epochs)
 
 
 def file_config(model, optimizer, filename, scheduler=None, resumed_epoch=None):

--- a/distiller/knowledge_distillation.py
+++ b/distiller/knowledge_distillation.py
@@ -85,8 +85,10 @@ class KnowledgeDistillationPolicy(ScheduledTrainingPolicy):
 
     """
     def __init__(self, student_model, teacher_model, temperature=1.0,
-                 loss_weights=DistillationLossWeights(0.5, 0.5, 0)):
-        super(KnowledgeDistillationPolicy, self).__init__()
+                 loss_weights=DistillationLossWeights(0.5, 0.5, 0),
+                 defer_best_checkpoint=False):
+        super(KnowledgeDistillationPolicy, self).__init__(
+                defer_best_checkpoint=defer_best_checkpoint)
 
         if loss_weights.teacher != 0:
             raise NotImplementedError('Using teacher vs. labels loss is not supported yet, '

--- a/distiller/policy.py
+++ b/distiller/policy.py
@@ -99,18 +99,11 @@ class PruningPolicy(ScheduledTrainingPolicy):
         """
         super(PruningPolicy, self).__init__(classes, layers)
         self.pruner = pruner
-        self.levels = None
-        self.keep_mask = False
-        self.mini_batch_pruning_frequency = 0
-        self.mask_on_forward_only = False
-        self.use_double_copies = False
-        if pruner_args is not None:
-            if 'levels' in pruner_args:
-                self.levels = pruner_args['levels']
-            self.keep_mask = pruner_args.get('keep_mask', False)
-            self.mini_batch_pruning_frequency = pruner_args.get('mini_batch_pruning_frequency', 0)
-            self.mask_on_forward_only = pruner_args.get('mask_on_forward_only', False)
-            self.use_double_copies = pruner_args.get('use_double_copies', False)
+        self.levels = getattr(pruner_args, 'levels', None)
+        self.keep_mask = getattr(pruner_args, 'keep_mask', False)
+        self.mini_batch_pruning_frequency = getattr(pruner_args, 'mini_batch_pruning_frequency', 0)
+        self.mask_on_forward_only = getattr(pruner_args, 'mask_on_forward_only', False)
+        self.use_double_copies = getattr(pruner_args, 'use_double_copies', False)
         self.is_last_epoch = False
         self.mini_batch_id = 0          # The ID of the mini_batch within the present epoch
         self.global_mini_batch_id = 0   # The ID of the mini_batch within the present training session

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -85,26 +85,25 @@ class CompressionScheduler(object):
             masker = ParameterMasker(name)
             self.zeros_mask_dict[name] = masker
 
-    def add_policy(self, policy, epochs=None, starting_epoch=0, ending_epoch=1, frequency=1):
+    def add_policy(self, policy, epochs):
         """Add a new policy to the schedule.
 
         Args:
-            epochs (list): A list, or range, of epochs in which to apply the policy
+            epochs (range, iterable): epochs in which to apply the policy
         """
-
-        if epochs is None:
-            epochs = list(range(starting_epoch, ending_epoch, frequency))
-
         for epoch in epochs:
-            if epoch not in self.policies:
-                self.policies[epoch] = [policy]
-            else:
+            try:
                 self.policies[epoch].append(policy)
-            assert len(self.policies[epoch]) > 0
+            except KeyError:
+                self.policies[epoch] = [policy]
 
+        # if isinstance(epochs, range), then getattr, otherwise assume iterable
+        starting_epoch = getattr(epochs, 'start', epochs[0])
+        ending_epoch = getattr(epochs, 'stop', max(epochs[-1], epochs[0]+1))
+        epoch_step = getattr(epochs, 'step', (ending_epoch - starting_epoch) // len(epochs))
         self.sched_metadata[policy] = {'starting_epoch': starting_epoch,
                                        'ending_epoch': ending_epoch,
-                                       'frequency': frequency}
+                                       'frequency': epoch_step}
 
     def on_epoch_begin(self, epoch, optimizer=None):
         if epoch in self.policies:

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -84,9 +84,10 @@ class CompressionScheduler(object):
         for name, param in self.model.named_parameters():
             masker = ParameterMasker(name)
             self.zeros_mask_dict[name] = masker
+        self.global_policy_end_epoch = None
 
     def add_policy(self, policy, epochs):
-        """Add a new policy to the schedule.
+        """Add a new policy to the schedule and update global_policy_end_epoch.
 
         Args:
             epochs (range, iterable): epochs in which to apply the policy
@@ -104,6 +105,10 @@ class CompressionScheduler(object):
         self.sched_metadata[policy] = {'starting_epoch': starting_epoch,
                                        'ending_epoch': ending_epoch,
                                        'frequency': epoch_step}
+
+        if policy.defer_best_checkpoint:
+            self.global_policy_end_epoch = (max(self.global_policy_end_epoch, ending_epoch)
+                if self.global_policy_end_epoch is not None else ending_epoch)
 
     def on_epoch_begin(self, epoch, optimizer=None):
         if epoch in self.policies:

--- a/distiller/thinning.py
+++ b/distiller/thinning.py
@@ -402,6 +402,7 @@ def create_thinning_recipe_filters(sgraph, model, zeros_mask_dict):
 class StructureRemover(ScheduledTrainingPolicy):
     """A policy which applies a network thinning function"""
     def __init__(self, thinning_func_str, arch, dataset):
+        super(StructureRemover, self).__init__()
         self.thinning_func = globals()[thinning_func_str]
         self.arch = arch
         self.dataset = dataset

--- a/distiller/thinning.py
+++ b/distiller/thinning.py
@@ -401,8 +401,8 @@ def create_thinning_recipe_filters(sgraph, model, zeros_mask_dict):
 
 class StructureRemover(ScheduledTrainingPolicy):
     """A policy which applies a network thinning function"""
-    def __init__(self, thinning_func_str, arch, dataset):
-        super(StructureRemover, self).__init__()
+    def __init__(self, thinning_func_str, arch, dataset, defer_best_checkpoint=False):
+        super(StructureRemover, self).__init__(defer_best_checkpoint=defer_best_checkpoint)
         self.thinning_func = globals()[thinning_func_str]
         self.arch = arch
         self.dataset = dataset

--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -452,7 +452,9 @@ def activation_channels_apoz(activation):
     return 100 - featuremap_apoz_mat.mean(dim=0).mul(100).cpu()
 
 
-def log_training_progress(stats_dict, params_dict, epoch, steps_completed, total_steps, log_freq, loggers):
+def log_training_and_weights_dist(stats_dict, params_dict,
+        epoch, steps_completed, step_in_current_epoch, *loggers,
+        train_steps_per_epoch=None, log_period=1):
     """Log information about the training progress, and the distribution of the weight tensors.
 
     Args:
@@ -465,19 +467,16 @@ def log_training_progress(stats_dict, params_dict, epoch, steps_completed, total
                                     ('Top5', top5)]))
         params_dict: A parameter dictionary, such as the one returned by model.named_parameters()
         epoch: The current epoch
-        steps_completed: The current step in the epoch
-        total_steps: The total number of training steps taken so far
-        log_freq: The number of steps between logging records
-        loggers: A list of loggers to send the log info to
+        steps_completed: training steps since the begining of time
+        step_in_current_epoch: training steps in current epoch
+        loggers [logger.DataLogger iterable]: logger(s) to send the log info to
+        train_steps_per_epoch: number of mini-batches in current epoch (used by Pylogger exclusively)
+        log_period: The number of steps between logging records
     """
-    if loggers is None:
-        return
-    if not isinstance(loggers, list):
-        loggers = [loggers]
     for logger in loggers:
-        logger.log_training_progress(stats_dict, epoch,
-                                     steps_completed,
-                                     total_steps, freq=log_freq)
+        logger.log_training_progress(
+            stats_dict, epoch, steps_completed, step_in_current_epoch,
+            train_steps_per_epoch=train_steps_per_epoch)
         logger.log_weights_distribution(params_dict, steps_completed)
 
 

--- a/docs-src/docs/tutorial-lang_model.md
+++ b/docs-src/docs/tutorial-lang_model.md
@@ -193,8 +193,11 @@ if batch % args.log_interval == 0 and batch > 0:
             ('Batch Time', elapsed * 1000)])
         )
     steps_completed = batch + 1
-    distiller.log_training_progress(stats, model.named_parameters(), epoch, steps_completed,
-                                    steps_per_epoch, args.log_interval, [tflogger])
+    absolute_train_step = epoch*steps_per_epoch + steps_completed
+    distiller.log_training_and_weights_dist(
+        stats, model.named_parameters(), epoch,
+        absolute_train_step, steps_completed, tflogger,
+        train_steps_per_epoch=steps_per_epoch, log_period=args.log_interval)
 </code></pre>
 
 

--- a/examples/automated_deep_compression/ADC.py
+++ b/examples/automated_deep_compression/ADC.py
@@ -587,10 +587,7 @@ class DistillerWrapperEnvironment(gym.Env):
 
         stats = ('Peformance/Validation/',
                  OrderedDict([('requested_action', pruning_action)]))
-
-        distiller.log_training_progress(stats, None,
-                                        self.episode, steps_completed=self.current_layer_id,
-                                        total_steps=self.amc_cfg.conv_cnt, log_freq=1, loggers=[self.tflogger])
+        self.tflogger.log_training_progress(stats, self.episode, None)
 
         if self.episode_is_done():
             msglogger.info("Episode is ending")
@@ -733,8 +730,10 @@ class DistillerWrapperEnvironment(gym.Env):
                                   ('macs_normalized', macs_normalized*100),
                                   ('log(total_macs)', math.log(total_macs)),
                                   ('total_nnz', int(total_nnz))]))
-            distiller.log_training_progress(stats, None, self.episode, steps_completed=0, total_steps=1,
-                                            log_freq=1, loggers=[self.tflogger, self.pylogger])
+            for logger in [self.tflogger, self.pylogger]:
+                logger.log_training_progress(stats, self.episode, self.episode,
+                    0, train_steps_per_epoch=1)
+
         return reward, top1, total_macs, total_nnz
 
     def create_network_record_file(self):

--- a/examples/automated_deep_compression/ADC.py
+++ b/examples/automated_deep_compression/ADC.py
@@ -585,7 +585,7 @@ class DistillerWrapperEnvironment(gym.Env):
         msglogger.info("self._removed_macs={}".format(self._removed_macs))
         assert math.isclose(layer_macs_after_action / layer_macs, 1 - pruning_action)
 
-        stats = ('Peformance/Validation/',
+        stats = ('Performance/Validation/',
                  OrderedDict([('requested_action', pruning_action)]))
         self.tflogger.log_training_progress(stats, self.episode, None)
 
@@ -721,7 +721,7 @@ class DistillerWrapperEnvironment(gym.Env):
             msglogger.info("Total parameters left: %.2f%%" % (compression*100))
             msglogger.info("Total compute left: %.2f%%" % (total_macs/self.dense_model_macs*100))
 
-            stats = ('Peformance/EpisodeEnd/',
+            stats = ('Performance/EpisodeEnd/',
                      OrderedDict([('Loss', vloss),
                                   ('Top1', top1),
                                   ('Top5', top5),

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -301,7 +301,7 @@ def main():
                                                 collector=collectors["sparsity"])
             save_collectors_data(collectors, msglogger.logdir)
 
-        stats = ('Peformance/Validation/',
+        stats = ('Performance/Validation/',
                  OrderedDict([('Loss', vloss),
                               ('Top1', top1),
                               ('Top5', top5)]))
@@ -430,7 +430,7 @@ def train(train_loader, model, criterion, optimizer, epoch,
             stats_dict.update(errs)
             stats_dict['LR'] = optimizer.param_groups[0]['lr']
             stats_dict['Time'] = batch_time.mean
-            stats = ('Peformance/Training/', stats_dict)
+            stats = ('Performance/Training/', stats_dict)
 
             params = model.named_parameters() if args.log_params_histograms else None
             current_training_step = accumulated_training_steps + steps_completed

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -164,8 +164,9 @@ def main():
     # We can optionally resume from a checkpoint
     optimizer = None
     if args.resume:
-        # initiate SGD with dummy lr
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
+        if not args.reset_optimizer:
+            # initiate SGD with dummy lr
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
             model, args.resume, optimizer=optimizer)
         model.to(args.device)
@@ -236,7 +237,7 @@ def main():
         # The main use-case for this sample application is CNN compression. Compression
         # requires a compression schedule configuration file in YAML.
         compression_scheduler = distiller.file_config(model, optimizer, args.compress, compression_scheduler,
-            (start_epoch-1) if args.resume else None)
+            (start_epoch-1) if (args.resume and not args.reset_optimizer) else None)
         # Model is re-transferred to GPU in case parameters were added (e.g. PACTQuantizer)
         model.to(args.device)
     elif compression_scheduler is None:

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -163,12 +163,12 @@ def main():
 
     # We can optionally resume from a checkpoint
     optimizer = None
-    if args.resume:
-        if not args.reset_optimizer:
+    if args.resume or args.load_state_dict:
+        if args.resume and not args.reset_optimizer:
             # initiate SGD with dummy lr
             optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
-            model, args.resume, optimizer=optimizer)
+            model, args.resume or args.load_state_dict, optimizer=optimizer)
         model.to(args.device)
 
     # Define loss function (criterion) and optimizer

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -185,7 +185,7 @@ def main():
             ]
         if user_optim_args:
             msglogger.warning('{} optimizer arguments are ignored.'.format(user_optim_args))
-            msglogger.info('setting optimizer arguments when optimizer is resumed'
+            msglogger.info('setting optimizer arguments when optimizer is resumed '
                 'from checkpoint is forbidden.')
     else:
         optimizer = torch.optim.SGD(model.parameters(), lr=args.lr,

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -259,8 +259,7 @@ def main():
             teacher = apputils.load_checkpoint(teacher, chkpt_file=args.kd_resume)[0]
         dlw = distiller.DistillationLossWeights(args.kd_distill_wt, args.kd_student_wt, args.kd_teacher_wt)
         args.kd_policy = distiller.KnowledgeDistillationPolicy(model, teacher, args.kd_temp, dlw)
-        compression_scheduler.add_policy(args.kd_policy, starting_epoch=args.kd_start_epoch, ending_epoch=args.epochs,
-                                         frequency=1)
+        compression_scheduler.add_policy(args.kd_policy, range(args.kd_start_epoch, args.epochs, 1))
 
         msglogger.info('\nStudent-Teacher knowledge distillation enabled:')
         msglogger.info('\tTeacher Model: %s', args.kd_teacher)

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -48,6 +48,8 @@ def get_parser():
                     metavar='M', help='momentum')
     optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
                     metavar='W', help='weight decay (default: 1e-4)')
+    parser.add_argument('--reset-optimizer', '--reset-lr', action='store_true',
+                        help='Flag to override optimizer if resumed from checkpoint')
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -40,12 +40,15 @@ def get_parser():
                         help='number of total epochs to run')
     parser.add_argument('-b', '--batch-size', default=256, type=int,
                         metavar='N', help='mini-batch size (default: 256)')
-    parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
-                        metavar='LR', help='initial learning rate')
-    parser.add_argument('--momentum', default=0.9, type=float, metavar='M',
-                        help='momentum')
-    parser.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
-                        metavar='W', help='weight decay (default: 1e-4)')
+
+    optimizer_args = parser.add_argument_group('optimizer_arguments')
+    optimizer_args.add_argument('--lr', '--learning-rate', default=0.1,
+                    type=float, metavar='LR', help='initial learning rate')
+    optimizer_args.add_argument('--momentum', default=0.9, type=float,
+                    metavar='M', help='momentum')
+    optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
+                    metavar='W', help='weight decay (default: 1e-4)')
+
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
     parser.add_argument('--resume', default='', type=str, metavar='PATH',

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -53,8 +53,13 @@ def get_parser():
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
-    parser.add_argument('--resume', default='', type=str, metavar='PATH',
+
+    load_checkpoint_group = parser.add_mutually_exclusive_group()
+    load_checkpoint_group.add_argument('--resume', default='', type=str, metavar='PATH',
                         help='path to latest checkpoint (default: none)')
+    load_checkpoint_group.add_argument('--load-state-dict', default='', type=str, metavar='PATH',
+                        help='load only state dict field from checkpoint at given path')
+
     parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                         help='evaluate model on validation set')
     parser.add_argument('--pretrained', dest='pretrained', action='store_true',

--- a/examples/word_language_model/main.py
+++ b/examples/word_language_model/main.py
@@ -265,8 +265,11 @@ def train(epoch, optimizer, compression_scheduler=None):
                     ('Batch Time', elapsed * 1000)])
                 )
             steps_completed = batch + 1
-            distiller.log_training_progress(stats, model.named_parameters(), epoch, steps_completed,
-                                            steps_per_epoch, args.log_interval, [tflogger])
+            absolute_train_step = epoch*steps_per_epoch + steps_completed
+            distiller.log_training_and_weights_dist(
+                stats, model.named_parameters(), epoch,
+                absolute_train_step, steps_completed, tflogger,
+                train_steps_per_epoch=steps_per_epoch, log_period=args.log_interval)
 
 
 def export_onnx(path, batch_size, seq_len):
@@ -339,7 +342,7 @@ try:
             OrderedDict([
                 ('Loss', val_loss),
                 ('Perplexity', math.exp(val_loss))]))
-        tflogger.log_training_progress(stats, epoch, 0, total=1, freq=1)
+        tflogger.log_training_progress(stats, epoch, None)
 
         with open(args.save, 'wb') as f:
             torch.save(model, f)

--- a/examples/word_language_model/main.py
+++ b/examples/word_language_model/main.py
@@ -257,7 +257,7 @@ def train(epoch, optimizer, compression_scheduler=None):
                 elapsed * 1000 / args.log_interval, cur_loss, math.exp(cur_loss)))
             total_loss = 0
             start_time = time.time()
-            stats = ('Peformance/Training/',
+            stats = ('Performance/Training/',
                 OrderedDict([
                     ('Loss', cur_loss),
                     ('Perplexity', math.exp(cur_loss)),
@@ -338,7 +338,7 @@ try:
 
         distiller.log_weights_sparsity(model, epoch, loggers=[tflogger, pylogger])
 
-        stats = ('Peformance/Validation/',
+        stats = ('Performance/Validation/',
             OrderedDict([
                 ('Loss', val_loss),
                 ('Perplexity', math.exp(val_loss))]))

--- a/tests/full_flow_tests/steplr_training_resnet20_cifar.yaml
+++ b/tests/full_flow_tests/steplr_training_resnet20_cifar.yaml
@@ -1,0 +1,14 @@
+# python3 compress_classifier.py  --lr=0.1 --arch=resnet20_cifar ../../../data.cifar10 --compress=../../tests/full_flow_tests/steplr_training_resnet20_cifar.yaml
+
+lr_schedulers:
+  training_lr:
+    class: StepLR
+    step_size: 1
+    gamma: 0.10
+
+policies:
+    - lr_scheduler:
+        instance_name: training_lr
+      starting_epoch: 0
+      ending_epoch: 10
+      frequency: 1

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -59,7 +59,7 @@ def test_load():
     assert start_epoch == 180
 
 
-def test_load_state_dict():
+def test_load_state_dict_implicit():
     # prepare lean checkpoint
     state_dict_arrays = torch.load('../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar').get('state_dict')
 
@@ -69,6 +69,36 @@ def test_load_state_dict():
         model, compression_scheduler, optimizer, start_epoch = load_checkpoint(model, tmpfile.name)
 
     assert len(list(model.named_modules())) >= len([x for x in state_dict_arrays if x.endswith('weight')]) > 0
+    assert compression_scheduler is None
+    assert optimizer is None
+    assert start_epoch == 0
+
+
+def test_load_lean_checkpoint_1():
+    # prepare lean checkpoint
+    state_dict_arrays = torch.load('../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar').get('state_dict')
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        torch.save({'state_dict': state_dict_arrays}, tmpfile.name)
+        model = create_model(False, 'cifar10', 'resnet20_cifar')
+        model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
+            model, tmpfile.name, torch.optim.SGD(model.parameters(), lr=0.36787944117),
+            lean_checkpoint=True)
+
+    assert compression_scheduler is None
+    assert optimizer is None
+    assert start_epoch == 0
+
+
+def test_load_lean_checkpoint_2():
+    checkpoint_filename = '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar'
+
+    model = create_model(False, 'cifar10', 'resnet20_cifar', 0)
+    model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
+        model, checkpoint_filename,
+        torch.optim.SGD(model.parameters(), lr=0.36787944117),
+        lean_checkpoint=True)
+
     assert compression_scheduler is None
     assert optimizer is None
     assert start_epoch == 0
@@ -91,6 +121,7 @@ def test_load_negative():
         model, compression_scheduler, optimizer, start_epoch = load_checkpoint(model,
             'THIS_IS_AN_ERROR/checkpoint_trained_dense.pth.tar')
 
+
 def test_load_gpu_model_on_cpu():
     # Issue #148
     CPU_DEVICE_ID = -1
@@ -103,6 +134,19 @@ def test_load_gpu_model_on_cpu():
     assert compression_scheduler is not None
     assert optimizer is None
     assert start_epoch == 180
+    assert distiller.model_device(model) == 'cpu'
+
+
+def test_load_gpu_model_on_cpu_lean_checkpoint():
+    CPU_DEVICE_ID = -1
+    checkpoint_filename = '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar'
+
+    model = create_model(False, 'cifar10', 'resnet20_cifar', device_ids=CPU_DEVICE_ID)
+    model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
+        model, checkpoint_filename, lean_checkpoint=True)
+
+    assert compression_scheduler is None
+    assert optimizer is None
     assert distiller.model_device(model) == 'cpu'
 
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -296,7 +296,7 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
     conv2 = common.find_module_by_name(model_2, pair[1])
     assert conv2 is not None
     with pytest.raises(KeyError):
-        model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+        model_2, compression_scheduler, optimizer, start_epoch, _ = load_checkpoint(model_2, 'checkpoint.pth.tar')
     compression_scheduler = distiller.CompressionScheduler(model)
     hasattr(model, 'thinning_recipes')
 
@@ -304,13 +304,13 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
 
     # (2)
     save_checkpoint(epoch=0, arch=config.arch, model=model, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch, _ = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done")
 
     # (3)
     save_checkpoint(epoch=0, arch=config.arch, model=model_2, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch, _ = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done 2")
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -296,7 +296,7 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
     conv2 = common.find_module_by_name(model_2, pair[1])
     assert conv2 is not None
     with pytest.raises(KeyError):
-        model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+        model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     compression_scheduler = distiller.CompressionScheduler(model)
     hasattr(model, 'thinning_recipes')
 
@@ -304,13 +304,13 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
 
     # (2)
     save_checkpoint(epoch=0, arch=config.arch, model=model, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done")
 
     # (3)
     save_checkpoint(epoch=0, arch=config.arch, model=model_2, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done 2")
 


### PR DESCRIPTION
I address in this patch several issues/bugs:
 * Fix weights distribution histogram. (It's broken.)
 * Fix training steps: the former behavior assumed batch size is a constant
    Before the patch, when resumed training with different batch size, the training step was skewed
 * Fix typo in tflogger path (this will have visual effect on comparing new log files with the old!)
 * Fix utils.log_training_progress. It was misused, and therefore, bug-prone.
    I renamed the function, so it makes the refactoring safer to commit.
    I limited the use of this function to where I saw fit. Although both serve similar purpose, Pylogger and TFlogger are very different beasts, and require different parameters more often than not.

I tested it, and enjoyed using it, but I might have overlooked many scenarios, especially in ADC.py and main.py areas which I'm hardly familiar with.

This branch is dependent on 2 unmerged PRs: #169  and #132 