### PR TITLE
Load optimizer

### DIFF
--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -74,8 +74,9 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
         shutil.copyfile(fullpath, fullpath_best)
 
 
-def load_lean_checkpoint(model, chkpt_file):
-    return load_checkpoint(model, chkpt_file, lean_checkpoint=True)[0]
+def load_lean_checkpoint(model, chkpt_file, model_device=None):
+    return load_checkpoint(model, chkpt_file, model_device=model_device,
+                           lean_checkpoint=True)[0]
 
 
 def load_checkpoint(model, chkpt_file, optimizer=None, model_device=None, *, lean_checkpoint=False):

--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -151,6 +151,7 @@ def load_checkpoint(model, chkpt_file, optimizer=None, *, lean_checkpoint=False)
         optimizer.load_state_dict(checkpoint['optimizer'])
         msglogger.info('Optimizer of type {type} was loaded from checkpoint'.format(
             type=type(optimizer)))
+        msglogger.info('Optimizer Args: %s', optimizer.defaults)
         msglogger.debug('Optimizer state_dict: {}'.format(optimizer.state_dict()))
 
     msglogger.info("=> loaded checkpoint '{f}' (epoch {e})".format(f=str(chkpt_file),

--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -78,7 +78,7 @@ def load_lean_checkpoint(model, chkpt_file):
     return load_checkpoint(model, chkpt_file, lean_checkpoint=True)[0]
 
 
-def load_checkpoint(model, chkpt_file, optimizer=None, *, lean_checkpoint=False):
+def load_checkpoint(model, chkpt_file, optimizer=None, model_device=None, *, lean_checkpoint=False):
     """Load a pytorch training checkpoint.
 
     Args:
@@ -86,6 +86,8 @@ def load_checkpoint(model, chkpt_file, optimizer=None, *, lean_checkpoint=False)
         chkpt_file: the checkpoint file
         lean_checkpoint: if set, read into model only 'state_dict' field
         optimizer: [deprecated argument]
+        model_device [str]: if set, call model.to($model_device)
+                This should be set to either 'cpu' or 'gpu'.
     :returns: updated model, compression_scheduler, optimizer, start_epoch
     """
     if not os.path.isfile(chkpt_file):
@@ -142,6 +144,8 @@ def load_checkpoint(model, chkpt_file, optimizer=None, *, lean_checkpoint=False)
     if normalize_dataparallel_keys:
             checkpoint['state_dict'] = {normalize_module_name(k): v for k, v in checkpoint['state_dict'].items()}
     model.load_state_dict(checkpoint['state_dict'])
+    if model_device is not None:
+        model.to(model_device)
 
     if lean_checkpoint:
         msglogger.info("=> loaded 'state_dict' from checkpoint '{}'".format(str(chkpt_file)))

--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -88,7 +88,7 @@ def load_checkpoint(model, chkpt_file, optimizer=None, model_device=None, *, lea
         lean_checkpoint: if set, read into model only 'state_dict' field
         optimizer: [deprecated argument]
         model_device [str]: if set, call model.to($model_device)
-                This should be set to either 'cpu' or 'gpu'.
+                This should be set to either 'cpu' or 'cuda'.
     :returns: updated model, compression_scheduler, optimizer, start_epoch
     """
     if not os.path.isfile(chkpt_file):

--- a/distiller/policy.py
+++ b/distiller/policy.py
@@ -21,6 +21,7 @@
 - LRPolicy: learning-rate decay scheduling
 """
 import torch
+import torch.optim.lr_scheduler
 from collections import namedtuple
 
 import logging
@@ -210,7 +211,11 @@ class LRPolicy(ScheduledTrainingPolicy):
         self.lr_scheduler = lr_scheduler
 
     def on_epoch_begin(self, model, zeros_mask_dict, meta, **kwargs):
-        self.lr_scheduler.step(**kwargs)
+        if isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
+            # Note: ReduceLROnPlateau doesn't inherit from _LRScheduler
+            self.lr_scheduler.step(**kwargs)
+        else:
+            self.lr_scheduler.step(epoch=kwargs.get('epoch', None))
 
 
 class QuantizationPolicy(ScheduledTrainingPolicy):

--- a/distiller/policy.py
+++ b/distiller/policy.py
@@ -42,7 +42,7 @@ class ScheduledTrainingPolicy(object):
         self.classes = classes
         self.layers = layers
 
-    def on_epoch_begin(self, model, zeros_mask_dict, meta):
+    def on_epoch_begin(self, model, zeros_mask_dict, meta, **kwargs):
         """A new epcoh is about to begin"""
         pass
 
@@ -115,7 +115,7 @@ class PruningPolicy(ScheduledTrainingPolicy):
         self.mini_batch_id = 0          # The ID of the mini_batch within the present epoch
         self.global_mini_batch_id = 0   # The ID of the mini_batch within the present training session
 
-    def on_epoch_begin(self, model, zeros_mask_dict, meta):
+    def on_epoch_begin(self, model, zeros_mask_dict, meta, **kwargs):
         msglogger.debug("Pruner {} is about to prune".format(self.pruner.name))
         self.mini_batch_id = 0
         self.is_last_epoch = meta['current_epoch'] == (meta['ending_epoch'] - 1)
@@ -169,7 +169,7 @@ class RegularizationPolicy(ScheduledTrainingPolicy):
         self.keep_mask = keep_mask
         self.is_last_epoch = False
 
-    def on_epoch_begin(self, model, zeros_mask_dict, meta):
+    def on_epoch_begin(self, model, zeros_mask_dict, meta, **kwargs):
         self.is_last_epoch = meta['current_epoch'] == (meta['ending_epoch'] - 1)
 
     def before_backward_pass(self, model, epoch, minibatch_id, minibatches_per_epoch, loss,
@@ -202,15 +202,15 @@ class RegularizationPolicy(ScheduledTrainingPolicy):
 
 
 class LRPolicy(ScheduledTrainingPolicy):
-    """ Learning-rate decay scheduling policy.
+    """Learning-rate decay scheduling policy.
 
     """
     def __init__(self, lr_scheduler):
         super(LRPolicy, self).__init__()
         self.lr_scheduler = lr_scheduler
 
-    def on_epoch_begin(self, model, zeros_mask_dict, meta):
-        self.lr_scheduler.step()
+    def on_epoch_begin(self, model, zeros_mask_dict, meta, **kwargs):
+        self.lr_scheduler.step(**kwargs)
 
 
 class QuantizationPolicy(ScheduledTrainingPolicy):

--- a/distiller/policy.py
+++ b/distiller/policy.py
@@ -213,9 +213,9 @@ class LRPolicy(ScheduledTrainingPolicy):
     def on_epoch_begin(self, model, zeros_mask_dict, meta, **kwargs):
         if isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
             # Note: ReduceLROnPlateau doesn't inherit from _LRScheduler
-            self.lr_scheduler.step(**kwargs)
+            self.lr_scheduler.step(kwargs['metrics'], epoch=meta['current_epoch'])
         else:
-            self.lr_scheduler.step(epoch=kwargs.get('epoch', None))
+            self.lr_scheduler.step(epoch=meta['current_epoch'])
 
 
 class QuantizationPolicy(ScheduledTrainingPolicy):

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -111,7 +111,7 @@ class CompressionScheduler(object):
             meta = self.sched_metadata[policy]
             meta['current_epoch'] = epoch
             policy.on_epoch_begin(self.model, self.zeros_mask_dict, meta,
-                                  epoch=epoch, **kwargs)
+                                  **kwargs)
 
     def on_minibatch_begin(self, epoch, minibatch_id, minibatches_per_epoch, optimizer=None):
         if epoch in self.policies:

--- a/distiller/scheduler.py
+++ b/distiller/scheduler.py
@@ -106,12 +106,12 @@ class CompressionScheduler(object):
                                        'ending_epoch': ending_epoch,
                                        'frequency': frequency}
 
-    def on_epoch_begin(self, epoch, optimizer=None):
-        if epoch in self.policies:
-            for policy in self.policies[epoch]:
-                meta = self.sched_metadata[policy]
-                meta['current_epoch'] = epoch
-                policy.on_epoch_begin(self.model, self.zeros_mask_dict, meta)
+    def on_epoch_begin(self, epoch, optimizer=None, **kwargs):
+        for policy in self.policies.get(epoch, list()):
+            meta = self.sched_metadata[policy]
+            meta['current_epoch'] = epoch
+            policy.on_epoch_begin(self.model, self.zeros_mask_dict, meta,
+                                  epoch=epoch, **kwargs)
 
     def on_minibatch_begin(self, epoch, minibatch_id, minibatches_per_epoch, optimizer=None):
         if epoch in self.policies:

--- a/distiller/thinning.py
+++ b/distiller/thinning.py
@@ -542,7 +542,7 @@ def execute_thinning_recipe(model, zeros_mask_dict, recipe, optimizer, loaded_fr
                                   new_shape=directive[3] if len(directive)==4 else None):
                 msglogger.debug("Updated velocity buffer %s" % param_name)
             else:
-                msglogger.debug('Failed to update the optimizer by thinnig directive')
+                msglogger.debug('Failed to update the optimizer by thinning directive')
 
             if not loaded_from_file:
                 # If the masks are loaded from a checkpoint file, then we don't need to change

--- a/distiller/thinning.py
+++ b/distiller/thinning.py
@@ -470,7 +470,7 @@ def optimizer_thinning(optimizer, param, dim, indices, new_shape=None):
             if id(p) != id(param):
                 continue
             param_state = optimizer.state[p]
-            if ('momentum_buffer' in param_state) and (param_state['momentum_buffer'] is not None):
+            if param_state.get('momentum_buffer', None) is not None:
                 param_state['momentum_buffer'] = torch.index_select(param_state['momentum_buffer'], dim, indices)
                 if new_shape is not None:
                     msglogger.debug("optimizer_thinning: new shape {}".format(*new_shape))

--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -39,6 +39,10 @@ def model_device(model):
     return 'cpu'
 
 
+def optimizer_device_name(opt):
+    return str(list(list(opt.state)[0])[0].device)
+
+
 def to_np(var):
     return var.data.cpu().numpy()
 

--- a/examples/agp-pruning/mobilenet.imagenet.schedule_agp.yaml
+++ b/examples/agp-pruning/mobilenet.imagenet.schedule_agp.yaml
@@ -1,4 +1,5 @@
-# time python3 compress_classifier.py -a=mobilenet -p=50 --lr=0.001 ../../../data.imagenet/ -j=22 --resume=mobilenet_sgd_68.848.pth.tar --epochs=96 --compress=../agp-pruning//mobilenet.imagenet.schedule_agp.yaml
+# time python3 compress_classifier.py -a=mobilenet -p=50 --lr=0.001 ../../../data.imagenet/ -j=22 --resume-from=mobilenet_sgd_68.848.pth.tar --epochs=96 --compress=../agp-pruning//mobilenet.imagenet.schedule_agp.yaml  --reset-optimizer --vs=0
+#
 #
 # A pretrained MobileNet (width=1) can be downloaded from: https://github.com/marvis/pytorch-mobilenet (top1: 68.848; top5: 88.740)
 #
@@ -86,18 +87,18 @@ lr_schedulers:
 policies:
   - pruner:
       instance_name : 'conv50_pruner'
-    starting_epoch: 103
-    ending_epoch: 123
+    starting_epoch: 0
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name : 'conv60_pruner'
-    starting_epoch: 103
-    ending_epoch: 123
+    starting_epoch: 0
+    ending_epoch: 20
     frequency: 2
 
   - lr_scheduler:
       instance_name: pruning_lr
-    starting_epoch: 103
-    ending_epoch: 200
+    starting_epoch: 0
+    ending_epoch: 100
     frequency: 1

--- a/examples/agp-pruning/resnet20_filters.schedule_agp.yaml
+++ b/examples/agp-pruning/resnet20_filters.schedule_agp.yaml
@@ -14,7 +14,7 @@
 #     Total sparsity: 41.10
 #     # of parameters: 120,000  (=55.7% of the baseline parameters)
 #
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.3 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp.yaml -j=1 --deterministic --resume=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --validation-split=0
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.3 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp.yaml  --resume-from=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --vs=0 --reset-optimizer
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -109,29 +109,29 @@ extensions:
 policies:
   - pruner:
       instance_name : low_pruner
-    starting_epoch: 180
-    ending_epoch: 210
+    starting_epoch: 0
+    ending_epoch: 30
     frequency: 2
 
   - pruner:
       instance_name : fine_pruner
-    starting_epoch: 210
-    ending_epoch: 230
+    starting_epoch: 30
+    ending_epoch: 50
     frequency: 2
 
   - pruner:
       instance_name : fc_pruner
-    starting_epoch: 210
-    ending_epoch: 230
+    starting_epoch: 30
+    ending_epoch: 50
     frequency: 2
 
 # After completeing the pruning, we perform network thinning and continue fine-tuning.
   - extension:
       instance_name: net_thinner
-    epochs: [212]
+    epochs: [32]
 
   - lr_scheduler:
       instance_name: pruning_lr
-    starting_epoch: 180
+    starting_epoch: 0
     ending_epoch: 400
     frequency: 1

--- a/examples/agp-pruning/resnet20_filters.schedule_agp_2.yaml
+++ b/examples/agp-pruning/resnet20_filters.schedule_agp_2.yaml
@@ -103,20 +103,20 @@ extensions:
 policies:
   - pruner:
       instance_name : low_pruner
-    starting_epoch: 180
-    ending_epoch: 200
+    starting_epoch: 0
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name : fine_pruner
-    starting_epoch: 200
-    ending_epoch: 220
+    starting_epoch: 20
+    ending_epoch: 40
     frequency: 2
 
 # After completeing the pruning, we perform network thinning and continue fine-tuning.
   - extension:
       instance_name: net_thinner
-    epochs: [202]
+    epochs: [22]
 
   - lr_scheduler:
       instance_name: pruning_lr

--- a/examples/agp-pruning/resnet20_filters.schedule_agp_2.yaml
+++ b/examples/agp-pruning/resnet20_filters.schedule_agp_2.yaml
@@ -14,8 +14,7 @@
 #     Total sparsity: 41.84
 #     # of parameters: 143,488 (=53% of the baseline parameters)
 #
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.1 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp_2.yaml -j=1 --deterministic --resume=../ssl/checkpoints/checkpoint_trained_dense.pth.tar
-#
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.1 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp_2.yaml -j=1 --deterministic --resume-from=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --reset-optimizer
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+

--- a/examples/agp-pruning/resnet20_filters.schedule_agp_3.yaml
+++ b/examples/agp-pruning/resnet20_filters.schedule_agp_3.yaml
@@ -14,7 +14,7 @@
 #     Total sparsity: 56.41%
 #     # of parameters: 95922  (=35.4% of the baseline parameters ==> 64.6% sparsity)
 #
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.4 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp_3.yaml -j=1 --deterministic --resume=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --validation-split=0
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.4 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp_3.yaml  --resume-from=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --reset-optimizer --vs=0
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -116,26 +116,26 @@ extensions:
 policies:
   - pruner:
       instance_name : low_pruner
-    starting_epoch: 180
-    ending_epoch: 210
+    starting_epoch: 0
+    ending_epoch: 30
     frequency: 2
 
   - pruner:
       instance_name : fine_pruner1
-    starting_epoch: 210
-    ending_epoch: 230
+    starting_epoch: 30
+    ending_epoch: 50
     frequency: 2
 
   - pruner:
       instance_name : fine_pruner2
-    starting_epoch: 210
-    ending_epoch: 230
+    starting_epoch: 30
+    ending_epoch: 50
     frequency: 2
 
   - pruner:
       instance_name : fc_pruner
-    starting_epoch: 210
-    ending_epoch: 230
+    starting_epoch: 30
+    ending_epoch: 50
     frequency: 2
 
   # Currently the thinner is disabled until the the structure pruner is done, because it interacts
@@ -150,10 +150,10 @@ policies:
 # After completeing the pruning, we perform network thinning and continue fine-tuning.
   - extension:
       instance_name: net_thinner
-    epochs: [212]
+    epochs: [32]
 
   - lr_scheduler:
       instance_name: pruning_lr
-    starting_epoch: 180
+    starting_epoch: 0
     ending_epoch: 400
     frequency: 1

--- a/examples/agp-pruning/resnet20_filters.schedule_agp_4.yaml
+++ b/examples/agp-pruning/resnet20_filters.schedule_agp_4.yaml
@@ -14,7 +14,7 @@
 #     Total sparsity: 39.66
 #     # of parameters: 78,776  (=29.1% of the baseline parameters)
 #
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.3 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp_4.yaml -j=1 --deterministic --resume=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --validation-split=0
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.3 --epochs=180 --compress=../agp-pruning/resnet20_filters.schedule_agp_4.yaml --resume-from=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --reset-optimizer --vs=0
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -110,26 +110,26 @@ extensions:
 policies:
   - pruner:
       instance_name : low_pruner
-    starting_epoch: 180
-    ending_epoch: 210
+    starting_epoch: 0
+    ending_epoch: 30
     frequency: 2
 
   - pruner:
       instance_name : low_pruner_2
-    starting_epoch: 180
-    ending_epoch: 210
+    starting_epoch: 0
+    ending_epoch: 30
     frequency: 2
 
   - pruner:
       instance_name : fine_pruner
-    starting_epoch: 210
-    ending_epoch: 230
+    starting_epoch: 30
+    ending_epoch: 50
     frequency: 2
 
   - pruner:
       instance_name : fc_pruner
-    starting_epoch: 210
-    ending_epoch: 230
+    starting_epoch: 30
+    ending_epoch: 50
     frequency: 2
 
   # Currently the thinner is disabled until the the structure pruner is done, because it interacts
@@ -144,11 +144,10 @@ policies:
 # After completeing the pruning, we perform network thinning and continue fine-tuning.
   - extension:
       instance_name: net_thinner
-    #epochs: [181]
-    epochs: [212]
+    epochs: [32]
 
   - lr_scheduler:
       instance_name: pruning_lr
-    starting_epoch: 180
+    starting_epoch: 0
     ending_epoch: 400
     frequency: 1

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -242,7 +242,7 @@ def main():
     if args.kd_teacher:
         teacher = create_model(args.kd_pretrained, args.dataset, args.kd_teacher, device_ids=args.gpus)
         if args.kd_resume:
-            teacher = apputils.load_checkpoint(teacher, chkpt_file=args.kd_resume)[0]
+            teacher = apputils.load_lean_checkpoint(teacher, args.kd_resume)
         dlw = distiller.DistillationLossWeights(args.kd_distill_wt, args.kd_student_wt, args.kd_teacher_wt)
         args.kd_policy = distiller.KnowledgeDistillationPolicy(model, teacher, args.kd_temp, dlw)
         compression_scheduler.add_policy(args.kd_policy, starting_epoch=args.kd_start_epoch, ending_epoch=args.epochs,

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -161,7 +161,7 @@ def main():
     if args.earlyexit_thresholds:
         msglogger.info('=> using early-exit threshold values of %s', args.earlyexit_thresholds)
 
-    # TODO(barrh): args.deprecated_resume is deprecated since v0.3
+    # TODO(barrh): args.deprecated_resume is deprecated since v0.3.1
     if args.deprecated_resume:
         msglogger.warning('The "--resume" flag is deprecated. Please use "--resume-from=YOUR_PATH" instead.')
         if not args.reset_optimizer:

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -265,7 +265,9 @@ def main():
 
     ending_epoch = args.epochs if not args.reset_epochs else start_epoch + args.epochs
     if start_epoch >= ending_epoch:
-        raise ValueError('epoch count is too low, ')
+        msglogger.error(
+            'epoch count is too low, starting epoch is {} but total epochs set to {}'.format(
+            start_epoch, ending_epoch))
     for epoch in range(start_epoch, ending_epoch):
         # This is the main training loop.
         msglogger.info('\n')

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -159,18 +159,27 @@ def main():
         msglogger.info('=> using early-exit threshold values of %s', args.earlyexit_thresholds)
 
     # We can optionally resume from a checkpoint
+    optimizer = None
     if args.resume:
-        model, compression_scheduler, start_epoch = apputils.load_checkpoint(model, chkpt_file=args.resume)
+        # initiate SGD with dummy lr
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
+        try:
+            model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
+                model, args.resume, optimizer=optimizer)
+        except KeyError:
+            # try to load without optimizer
+            model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
+                model, args.resume)
         model.to(args.device)
 
-    # Define loss function (criterion) and optimizer
+    # Define loss function (criterion)
     criterion = nn.CrossEntropyLoss().to(args.device)
 
-    optimizer = torch.optim.SGD(model.parameters(), lr=args.lr,
-                                momentum=args.momentum,
-                                weight_decay=args.weight_decay)
-    msglogger.info('Optimizer Type: %s', type(optimizer))
-    msglogger.info('Optimizer Args: %s', optimizer.defaults)
+    if optimizer is None:
+        optimizer = torch.optim.SGD(model.parameters(),
+            lr=args.lr, momentum=args.momentum, weight_decay=args.weight_decay)
+        msglogger.info('Optimizer Type: %s', type(optimizer))
+        msglogger.info('Optimizer Args: %s', optimizer.defaults)
 
     if args.AMC:
         return automated_deep_compression(model, criterion, optimizer, pylogger, args)
@@ -214,7 +223,8 @@ def main():
     if args.compress:
         # The main use-case for this sample application is CNN compression. Compression
         # requires a compression schedule configuration file in YAML.
-        compression_scheduler = distiller.file_config(model, optimizer, args.compress, compression_scheduler)
+        compression_scheduler = distiller.file_config(model, optimizer, args.compress, compression_scheduler,
+            (start_epoch-1) if args.resume else None)
         # Model is re-transferred to GPU in case parameters were added (e.g. PACTQuantizer)
         model.to(args.device)
     elif compression_scheduler is None:
@@ -233,7 +243,7 @@ def main():
     if args.kd_teacher:
         teacher = create_model(args.kd_pretrained, args.dataset, args.kd_teacher, device_ids=args.gpus)
         if args.kd_resume:
-            teacher, _, _ = apputils.load_checkpoint(teacher, chkpt_file=args.kd_resume)
+            teacher = apputils.load_checkpoint(teacher, chkpt_file=args.kd_resume)[0]
         dlw = distiller.DistillationLossWeights(args.kd_distill_wt, args.kd_student_wt, args.kd_teacher_wt)
         args.kd_policy = distiller.KnowledgeDistillationPolicy(model, teacher, args.kd_temp, dlw)
         compression_scheduler.add_policy(args.kd_policy, starting_epoch=args.kd_start_epoch, ending_epoch=args.epochs,

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -170,11 +170,8 @@ def main():
     # We can optionally resume from a checkpoint
     optimizer = None
     if args.resumed_checkpoint_path:
-        if not args.reset_optimizer:
-            # initiate SGD with dummy lr
-            optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
-            model, args.resumed_checkpoint_path, optimizer=optimizer)
+            model, args.resumed_checkpoint_path)
         model.to(args.device)
     elif args.load_model_path:
         model = apputils.load_lean_checkpoint(model, args.load_model_path)
@@ -183,7 +180,9 @@ def main():
     # Define loss function (criterion)
     criterion = nn.CrossEntropyLoss().to(args.device)
 
-    if optimizer is None:
+    if optimizer is None or args.reset_optimizer:
+        if args.reset_optimizer and optimizer:
+            msglogger.info('Overriding resumed optimizer')
         optimizer = torch.optim.SGD(model.parameters(),
             lr=args.lr, momentum=args.momentum, weight_decay=args.weight_decay)
         msglogger.info('Optimizer Type: %s', type(optimizer))

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -181,7 +181,8 @@ def main():
         start_epoch = 0
         if optimizer is not None:
             optimizer = None
-            msglogger.info('Overriding resumed optimizer')
+            msglogger.info()
+            msglogger.info('reset_optimizer flag set: Overriding resumed optimizer and resetting epoch count to 0')
 
     # Define loss function (criterion)
     criterion = nn.CrossEntropyLoss().to(args.device)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -158,14 +158,22 @@ def main():
     if args.earlyexit_thresholds:
         msglogger.info('=> using early-exit threshold values of %s', args.earlyexit_thresholds)
 
+    # TODO(barrh): args.resume is deprecated since v0.3
+    if args.resume:
+        msglogger.warning('The "--resume" flag is deprecated. Please use "--load-checkpoint" instead.')
+        if not args.reset_optimizer:
+            msglogger.warning('If you wish to also reset the learning rate, call with --reset-lr')
+            args.reset_optimizer = True
+        args.checkpoint_path = args.resume
+
     # We can optionally resume from a checkpoint
     optimizer = None
-    if args.resume:
+    if args.checkpoint_path:
         if not args.reset_optimizer:
             # initiate SGD with dummy lr
             optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
-            model, args.resume, optimizer=optimizer)
+            model, args.checkpoint_path, optimizer=optimizer)
         model.to(args.device)
     elif args.load_state_dict:
         model = apputils.load_lean_checkpoint(model, args.load_state_dict)
@@ -223,7 +231,7 @@ def main():
         # The main use-case for this sample application is CNN compression. Compression
         # requires a compression schedule configuration file in YAML.
         compression_scheduler = distiller.file_config(model, optimizer, args.compress, compression_scheduler,
-            (start_epoch-1) if (args.resume and not args.reset_optimizer) else None)
+            (start_epoch-1) if (args.checkpoint_path and not args.reset_optimizer) else None)
         # Model is re-transferred to GPU in case parameters were added (e.g. PACTQuantizer)
         model.to(args.device)
     elif compression_scheduler is None:
@@ -231,10 +239,10 @@ def main():
 
     if args.thinnify:
         #zeros_mask_dict = distiller.create_model_masks_dict(model)
-        assert args.resume is not None, "You must use --resume to provide a checkpoint file to thinnify"
+        assert args.checkpoint_path is not None, "You must use --load-checkpoint to provide a checkpoint file to thinnify"
         distiller.remove_filters(model, compression_scheduler.zeros_mask_dict, args.arch, args.dataset, optimizer=None)
         apputils.save_checkpoint(0, args.arch, model, optimizer=None, scheduler=compression_scheduler,
-                                 name="{}_thinned".format(args.resume.replace(".pth.tar", "")), dir=msglogger.logdir)
+                                 name="{}_thinned".format(args.checkpoint_path.replace(".pth.tar", "")), dir=msglogger.logdir)
         print("Note: your model may have collapsed to random inference, so you may want to fine-tune")
         return
 
@@ -601,7 +609,7 @@ def evaluate_model(model, criterion, test_loader, loggers, activations_collector
     # the test dataset.
     # You can optionally quantize the model to 8-bit integer before evaluation.
     # For example:
-    # python3 compress_classifier.py --arch resnet20_cifar  ../data.cifar10 -p=50 --resume=checkpoint.pth.tar --evaluate
+    # python3 compress_classifier.py --arch resnet20_cifar  ../data.cifar10 -p=50 --load-checkpoint=checkpoint.pth.tar --evaluate
 
     if not isinstance(loggers, list):
         loggers = [loggers]

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -167,6 +167,9 @@ def main():
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
             model, args.resume, optimizer=optimizer)
         model.to(args.device)
+    elif args.load_state_dict:
+        model = apputils.load_lean_checkpoint(model, args.load_state_dict)
+        model.to(args.device)
 
     # Define loss function (criterion)
     criterion = nn.CrossEntropyLoss().to(args.device)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -271,7 +271,8 @@ def main():
         # This is the main training loop.
         msglogger.info('\n')
         if compression_scheduler:
-            compression_scheduler.on_epoch_begin(epoch,
+            compression_scheduler.on_epoch_begin(
+                epoch if not args.reset_optimizer else epoch - start_epoch,
                 metrics=(vloss if (epoch != start_epoch) else 10**6))
 
         # Train for one epoch

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -181,7 +181,7 @@ def main():
         start_epoch = 0
         if optimizer is not None:
             optimizer = None
-            msglogger.info('reset_optimizer flag set: Overriding resumed optimizer and resetting epoch count to 0')
+            msglogger.info('\nreset_optimizer flag set: Overriding resumed optimizer and resetting epoch count to 0')
 
     # Define loss function (criterion)
     criterion = nn.CrossEntropyLoss().to(args.device)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -171,11 +171,10 @@ def main():
     optimizer = None
     if args.resumed_checkpoint_path:
         model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
-            model, args.resumed_checkpoint_path)
-        model.to(args.device)
+            model, args.resumed_checkpoint_path, model_device=args.device)
     elif args.load_model_path:
-        model = apputils.load_lean_checkpoint(model, args.load_model_path)
-        model.to(args.device)
+        model = apputils.load_lean_checkpoint(model, args.load_model_path,
+                                              model_device=args.device)
 
     # Define loss function (criterion)
     criterion = nn.CrossEntropyLoss().to(args.device)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -181,7 +181,6 @@ def main():
         start_epoch = 0
         if optimizer is not None:
             optimizer = None
-            msglogger.info()
             msglogger.info('reset_optimizer flag set: Overriding resumed optimizer and resetting epoch count to 0')
 
     # Define loss function (criterion)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -267,7 +267,8 @@ def main():
         # This is the main training loop.
         msglogger.info('\n')
         if compression_scheduler:
-            compression_scheduler.on_epoch_begin(epoch)
+            compression_scheduler.on_epoch_begin(epoch,
+                metrics=(vloss if (epoch != start_epoch) else 10**6))
 
         # Train for one epoch
         with collectors_context(activations_collectors["train"]) as collectors:

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -161,15 +161,11 @@ def main():
     # We can optionally resume from a checkpoint
     optimizer = None
     if args.resume:
-        # initiate SGD with dummy lr
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
-        try:
-            model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
-                model, args.resume, optimizer=optimizer)
-        except KeyError:
-            # try to load without optimizer
-            model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
-                model, args.resume)
+        if not args.reset_optimizer:
+            # initiate SGD with dummy lr
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.36787944117)
+        model, compression_scheduler, optimizer, start_epoch = apputils.load_checkpoint(
+            model, args.resume, optimizer=optimizer)
         model.to(args.device)
 
     # Define loss function (criterion)
@@ -224,7 +220,7 @@ def main():
         # The main use-case for this sample application is CNN compression. Compression
         # requires a compression schedule configuration file in YAML.
         compression_scheduler = distiller.file_config(model, optimizer, args.compress, compression_scheduler,
-            (start_epoch-1) if args.resume else None)
+            (start_epoch-1) if (args.resume and not args.reset_optimizer) else None)
         # Model is re-transferred to GPU in case parameters were added (e.g. PACTQuantizer)
         model.to(args.device)
     elif compression_scheduler is None:

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -53,7 +53,7 @@ def get_parser():
                         metavar='N', help='print frequency (default: 10)')
 
     load_checkpoint_group = parser.add_argument_group('Resuming arguments')
-    load_checkpoint_group_exc = parser.add_mutually_exclusive_group()
+    load_checkpoint_group_exc = load_checkpoint_group.add_mutually_exclusive_group()
     # TODO(barrh): args.deprecated_resume is deprecated since v0.3
     load_checkpoint_group_exc.add_argument('--resume', dest='deprecated_resume', default='', type=str,
                         metavar='PATH', help=argparse.SUPPRESS)

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -48,6 +48,8 @@ def get_parser():
                     metavar='M', help='momentum')
     optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
                     metavar='W', help='weight decay (default: 1e-4)')
+    parser.add_argument('--reset-optimizer', '--reset-lr', action='store_true',
+                        help='Flag to override optimizer if resumed from checkpoint')
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -40,12 +40,15 @@ def get_parser():
                         help='number of total epochs to run')
     parser.add_argument('-b', '--batch-size', default=256, type=int,
                         metavar='N', help='mini-batch size (default: 256)')
-    parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
-                        metavar='LR', help='initial learning rate')
-    parser.add_argument('--momentum', default=0.9, type=float, metavar='M',
-                        help='momentum')
-    parser.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
-                        metavar='W', help='weight decay (default: 1e-4)')
+
+    optimizer_args = parser.add_argument_group('Optimizer arguments')
+    optimizer_args.add_argument('--lr', '--learning-rate', default=0.1,
+                    type=float, metavar='LR', help='initial learning rate')
+    optimizer_args.add_argument('--momentum', default=0.9, type=float,
+                    metavar='M', help='momentum')
+    optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
+                    metavar='W', help='weight decay (default: 1e-4)')
+
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
     parser.add_argument('--resume', default='', type=str, metavar='PATH',

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -55,8 +55,11 @@ def get_parser():
                         metavar='N', help='print frequency (default: 10)')
 
     load_checkpoint_group = parser.add_mutually_exclusive_group()
-    load_checkpoint_group.add_argument('--resume', '--load-checkpoint', default='', type=str,
-                        metavar='PATH', help='path to latest checkpoint')
+    # TODO(barrh): args.resume is deprecated since v0.3
+    load_checkpoint_group.add_argument('--resume', default='', type=str,
+                        metavar='PATH', help=argparse.SUPPRESS)
+    load_checkpoint_group.add_argument('--load-checkpoint', dest='checkpoint_path', default='',
+                        type=str, metavar='PATH', help='path to latest checkpoint')
     load_checkpoint_group.add_argument('--load-state-dict', default='', type=str, metavar='PATH',
                         help='path to checkpoint to load weights from (excluding other fields)')
     parser.add_argument('--pretrained', dest='pretrained', action='store_true',

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -54,7 +54,7 @@ def get_parser():
 
     load_checkpoint_group = parser.add_argument_group('Resuming arguments')
     load_checkpoint_group_exc = load_checkpoint_group.add_mutually_exclusive_group()
-    # TODO(barrh): args.deprecated_resume is deprecated since v0.3
+    # TODO(barrh): args.deprecated_resume is deprecated since v0.3.1
     load_checkpoint_group_exc.add_argument('--resume', dest='deprecated_resume', default='', type=str,
                         metavar='PATH', help=argparse.SUPPRESS)
     load_checkpoint_group_exc.add_argument('--resume-from', dest='resumed_checkpoint_path', default='',

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -36,8 +36,8 @@ def get_parser():
                         ' (default: resnet18)')
     parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',
                         help='number of data loading workers (default: 4)')
-    parser.add_argument('--epochs', default=90, type=int, metavar='N',
-                        help='number of total epochs to run')
+    parser.add_argument('--epochs', type=int, metavar='N',
+                        help='number of total epochs to run (default: 90')
     parser.add_argument('-b', '--batch-size', default=256, type=int,
                         metavar='N', help='mini-batch size (default: 256)')
 
@@ -48,27 +48,25 @@ def get_parser():
                     metavar='M', help='momentum')
     optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
                     metavar='W', help='weight decay (default: 1e-4)')
-    parser.add_argument('--exp-reset-optimizer', dest='reset_optimizer', action='store_true',
-                        help='Flag to override optimizer if resumed from checkpoint (experimental)')
-    parser.add_argument('--exp-reset-epochs', dest='reset_epochs', action='store_true',
-                        help='Flag to train for another N epochs (instead of N in total), '
-                            'if resumed from checkpoint (experimental)')
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
 
-    load_checkpoint_group = parser.add_mutually_exclusive_group()
+    load_checkpoint_group = parser.add_argument_group('Resuming arguments')
+    load_checkpoint_group_exc = parser.add_mutually_exclusive_group()
     # TODO(barrh): args.deprecated_resume is deprecated since v0.3
-    load_checkpoint_group.add_argument('--resume', dest='deprecated_resume', default='', type=str,
+    load_checkpoint_group_exc.add_argument('--resume', dest='deprecated_resume', default='', type=str,
                         metavar='PATH', help=argparse.SUPPRESS)
-    load_checkpoint_group.add_argument('--resume-from', dest='resumed_checkpoint_path', default='',
+    load_checkpoint_group_exc.add_argument('--resume-from', dest='resumed_checkpoint_path', default='',
                         type=str, metavar='PATH',
                         help='path to latest checkpoint. Use to resume paused training session.')
-    load_checkpoint_group.add_argument('--exp-load-weights-from', dest='load_model_path',
+    load_checkpoint_group_exc.add_argument('--exp-load-weights-from', dest='load_model_path',
                         default='', type=str, metavar='PATH',
-                        help='path to checkpoint to load weights from (excluding other fields)')
-    parser.add_argument('--pretrained', dest='pretrained', action='store_true',
+                        help='path to checkpoint to load weights from (excluding other fields) (experimental)')
+    load_checkpoint_group.add_argument('--pretrained', dest='pretrained', action='store_true',
                         help='use pre-trained model')
+    load_checkpoint_group.add_argument('--reset-optimizer', action='store_true',
+                        help='Flag to override optimizer if resumed from checkpoint. This will reset epochs count.')
 
     parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                         help='evaluate model on validation set')

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -53,12 +53,17 @@ def get_parser():
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
-    parser.add_argument('--resume', default='', type=str, metavar='PATH',
-                        help='path to latest checkpoint (default: none)')
-    parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
-                        help='evaluate model on validation set')
+
+    load_checkpoint_group = parser.add_mutually_exclusive_group()
+    load_checkpoint_group.add_argument('--resume', '--load-checkpoint', default='', type=str,
+                        metavar='PATH', help='path to latest checkpoint')
+    load_checkpoint_group.add_argument('--load-state-dict', default='', type=str, metavar='PATH',
+                        help='path to checkpoint to load weights from (excluding other fields)')
     parser.add_argument('--pretrained', dest='pretrained', action='store_true',
                         help='use pre-trained model')
+
+    parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
+                        help='evaluate model on validation set')
     parser.add_argument('--activation-stats', '--act-stats', nargs='+', metavar='PHASE', default=list(),
                         help='collect activation statistics on phases: train, valid, and/or test'
                         ' (WARNING: this slows down training)')

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -48,19 +48,24 @@ def get_parser():
                     metavar='M', help='momentum')
     optimizer_args.add_argument('--weight-decay', '--wd', default=1e-4, type=float,
                     metavar='W', help='weight decay (default: 1e-4)')
-    parser.add_argument('--reset-optimizer', '--reset-lr', action='store_true',
-                        help='Flag to override optimizer if resumed from checkpoint')
+    parser.add_argument('--exp-reset-optimizer', dest='reset_optimizer', action='store_true',
+                        help='Flag to override optimizer if resumed from checkpoint (experimental)')
+    parser.add_argument('--exp-reset-epochs', dest='reset_epochs', action='store_true',
+                        help='Flag to train for another N epochs (instead of N in total), '
+                            'if resumed from checkpoint (experimental)')
 
     parser.add_argument('--print-freq', '-p', default=10, type=int,
                         metavar='N', help='print frequency (default: 10)')
 
     load_checkpoint_group = parser.add_mutually_exclusive_group()
-    # TODO(barrh): args.resume is deprecated since v0.3
-    load_checkpoint_group.add_argument('--resume', default='', type=str,
+    # TODO(barrh): args.deprecated_resume is deprecated since v0.3
+    load_checkpoint_group.add_argument('--resume', dest='deprecated_resume', default='', type=str,
                         metavar='PATH', help=argparse.SUPPRESS)
-    load_checkpoint_group.add_argument('--load-checkpoint', dest='checkpoint_path', default='',
-                        type=str, metavar='PATH', help='path to latest checkpoint')
-    load_checkpoint_group.add_argument('--load-state-dict', default='', type=str, metavar='PATH',
+    load_checkpoint_group.add_argument('--resume-from', dest='resumed_checkpoint_path', default='',
+                        type=str, metavar='PATH',
+                        help='path to latest checkpoint. Use to resume paused training session.')
+    load_checkpoint_group.add_argument('--exp-load-weights-from', dest='load_model_path',
+                        default='', type=str, metavar='PATH',
                         help='path to checkpoint to load weights from (excluding other fields)')
     parser.add_argument('--pretrained', dest='pretrained', action='store_true',
                         help='use pre-trained model')

--- a/examples/network_surgery/resnet20.network_surgery.yaml
+++ b/examples/network_surgery/resnet20.network_surgery.yaml
@@ -31,7 +31,7 @@
 #     Total sparsity: 69.1%
 #     # of parameters: 83,671
 #
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.01 --epochs=180 --compress=../network_surgery/resnet20.network_surgery.yaml -j=1 --deterministic  --validation-split=0 --resume=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --masks-sparsity --num-best-scores=10
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.01 --epochs=180 --compress=../network_surgery/resnet20.network_surgery.yaml --vs=0 --resume-from=../ssl/checkpoints/checkpoint_trained_dense.pth.tar --reset-optimizer --masks-sparsity --num-best-scores=5
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -127,13 +127,13 @@ policies:
         mini_batch_pruning_frequency: 1
         mask_on_forward_only: True
         # use_double_copies: True
-    starting_epoch: 180
-    ending_epoch: 280
+    starting_epoch: 0
+    ending_epoch: 100
     frequency: 1
 
 
   - lr_scheduler:
       instance_name: training_lr
-    starting_epoch: 225
+    starting_epoch: 0
     ending_epoch: 400
     frequency: 1

--- a/examples/network_trimming/resnet56_cifar_activation_apoz.yaml
+++ b/examples/network_trimming/resnet56_cifar_activation_apoz.yaml
@@ -14,7 +14,7 @@
 #     Total MACs: 78,856,832
 #
 #
-# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../network_trimming/resnet56_cifar_activation_apoz.yaml --resume=checkpoint.resnet56_cifar_baseline.pth.tar -j=1 --deterministic --act-stats=valid
+# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../network_trimming/resnet56_cifar_activation_apoz.yaml --resume-from=checkpoint.resnet56_cifar_baseline.pth.tar --reset-optimizer --act-stats=valid
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -167,35 +167,34 @@ lr_schedulers:
 policies:
   - pruner:
       instance_name: filter_pruner_60
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name: filter_pruner_50
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name: filter_pruner_30
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name: filter_pruner_10
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - extension:
       instance_name: net_thinner
-    epochs: [200]
-    #epochs: [181]
+    epochs: [20]
 
   - lr_scheduler:
       instance_name: exp_finetuning_lr
-    starting_epoch: 190
+    starting_epoch: 10
     ending_epoch: 300
     frequency: 1

--- a/examples/network_trimming/resnet56_cifar_activation_apoz_v2.yaml
+++ b/examples/network_trimming/resnet56_cifar_activation_apoz_v2.yaml
@@ -14,7 +14,7 @@
 #     Total MACs: 67,797,632
 #
 #
-# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../network_trimming/resnet56_cifar_activation_apoz_v2.yaml --resume=checkpoint.resnet56_cifar_baseline.pth.tar -j=1 --deterministic --act-stats=valid
+# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../network_trimming/resnet56_cifar_activation_apoz_v2.yaml --resume-from=checkpoint.resnet56_cifar_baseline.pth.tar --reset-optimizer --act-stats=valid
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -168,34 +168,34 @@ lr_schedulers:
 policies:
   - pruner:
       instance_name: filter_pruner_60
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name: filter_pruner_50
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name: filter_pruner_30
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - pruner:
       instance_name: filter_pruner_10
-    starting_epoch: 181
-    ending_epoch: 200
+    starting_epoch: 1
+    ending_epoch: 20
     frequency: 2
 
   - extension:
       instance_name: net_thinner
-    epochs: [200]
+    epochs: [20]
 
   - lr_scheduler:
       instance_name: exp_finetuning_lr
-    starting_epoch: 190
+    starting_epoch: 10
     ending_epoch: 300
     frequency: 1

--- a/examples/pruning_filters_for_efficient_convnets/resnet56_cifar_channel_rank.yaml
+++ b/examples/pruning_filters_for_efficient_convnets/resnet56_cifar_channel_rank.yaml
@@ -5,7 +5,7 @@
 # However, instead of one-shot filter ranking and pruning, we perform one-shot channel ranking and
 # pruning, using L1-magnitude of the structures.
 #
-# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../pruning_filters_for_efficient_convnets/resnet56_cifar_channel_rank.yaml --resume=checkpoint.resnet56_cifar_baseline.pth.tar -j=1 --deterministic
+# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../pruning_filters_for_efficient_convnets/resnet56_cifar_channel_rank.yaml --resume-from=checkpoint.resnet56_cifar_baseline.pth.tar --reset-optimizer --vs=0
 #
 # Baseline results:
 #     Top1: 92.850    Top5: 99.780    Loss: 0.464
@@ -164,26 +164,26 @@ lr_schedulers:
 policies:
   - pruner:
       instance_name: filter_pruner_70
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_60
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_40
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_20
-    epochs: [180]
+    epochs: [0]
 
   - extension:
       instance_name: net_thinner
-    epochs: [180]
+    epochs: [0]
 
   - lr_scheduler:
       instance_name: exp_finetuning_lr
-    starting_epoch: 190
+    starting_epoch: 10
     ending_epoch: 300
     frequency: 1

--- a/examples/pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank.yaml
+++ b/examples/pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank.yaml
@@ -14,7 +14,7 @@
 # You may either train this model from scratch, or download it from the link below.
 # https://s3-us-west-1.amazonaws.com/nndistiller/pruning_filters_for_efficient_convnets/checkpoint.resnet56_cifar_baseline.pth.tar
 #
-# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank.yaml --resume=checkpoint.resnet56_cifar_baseline.pth.tar -j=1 --deterministic
+# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank.yaml --resume-from=checkpoint.resnet56_cifar_baseline.pth.tar  --reset-optimizer --vs=0
 #
 # Results: 62.7% of the original convolution MACs (when calculated using direct convolution)
 #
@@ -175,26 +175,26 @@ lr_schedulers:
 policies:
   - pruner:
       instance_name: filter_pruner_60
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_50
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_30
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_10
-    epochs: [180]
+    epochs: [0]
 
   - extension:
       instance_name: net_thinner
-    epochs: [180]
+    epochs: [0]
 
   - lr_scheduler:
       instance_name: exp_finetuning_lr
-    starting_epoch: 190
+    starting_epoch: 10
     ending_epoch: 300
     frequency: 1

--- a/examples/pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank_v2.yaml
+++ b/examples/pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank_v2.yaml
@@ -15,7 +15,7 @@
 # You may either train this model from scratch, or download it from the link below.
 # https://s3-us-west-1.amazonaws.com/nndistiller/pruning_filters_for_efficient_convnets/checkpoint.resnet56_cifar_baseline.pth.tar
 #
-# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank_v2.yaml --resume=checkpoint.resnet56_cifar_baseline.pth.tar -j=1 --deterministic
+# time python3 compress_classifier.py -a=resnet56_cifar -p=50 ../../../data.cifar10 --epochs=70 --lr=0.1 --compress=../pruning_filters_for_efficient_convnets/resnet56_cifar_filter_rank_v2.yaml --resume-from=checkpoint.resnet56_cifar_baseline.pth.tar --reset-optimizer --vs=0
 #
 # Results: 53.9% (1.85x) of the original convolution MACs (when calculated using direct convolution)
 #
@@ -177,26 +177,26 @@ lr_schedulers:
 policies:
   - pruner:
       instance_name: filter_pruner_70
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_60
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_40
-    epochs: [180]
+    epochs: [0]
 
   - pruner:
       instance_name: filter_pruner_20
-    epochs: [180]
+    epochs: [0]
 
   - extension:
       instance_name: net_thinner
-    epochs: [180]
+    epochs: [0]
 
   - lr_scheduler:
       instance_name: exp_finetuning_lr
-    starting_epoch: 190
+    starting_epoch: 10
     ending_epoch: 300
     frequency: 1

--- a/examples/ssl/ssl_channels-removal_finetuning.yaml
+++ b/examples/ssl/ssl_channels-removal_finetuning.yaml
@@ -3,7 +3,7 @@
 #
 # We save the output (i.e. checkpoint.pth.tar) in ../ssl/checkpoints/checkpoint_trained_channel_regularized_resnet20_finetuned.pth.tar
 #
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.3 --epochs=98 --compress=../ssl/ssl_channels-removal_finetuning.yaml -j=1 --deterministic --resume=../ssl/checkpoints/checkpoint_trained_channel_regularized_resnet20.pth.tar
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.3 --epochs=98 --compress=../ssl/ssl_channels-removal_finetuning.yaml --resume-from=../ssl/checkpoints/checkpoint_trained_channel_regularized_resnet20.pth.tar --reset-optimizer
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -58,6 +58,6 @@ lr_schedulers:
 policies:
   - lr_scheduler:
       instance_name: training_lr
-    starting_epoch: 45
+    starting_epoch: 0
     ending_epoch: 300
     frequency: 1

--- a/examples/ssl/ssl_channels-removal_finetuning_x1.8.yaml
+++ b/examples/ssl/ssl_channels-removal_finetuning_x1.8.yaml
@@ -7,7 +7,7 @@
 #
 # Total MACs: 22,583,936 == 55.3% compute density
 #
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.2 --epochs=98 --compress=../ssl/ssl_channels-removal_finetuning.yaml -j=1 --deterministic --resume=<enter-your-model>
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.2 --epochs=98 --compress=../ssl/ssl_channels-removal_finetuning_x1.8.yaml --reset-optimizer --resume-from=../ssl/checkpoints/checkpoint_trained_channel_regularized_resnet20.pth.tar
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+
@@ -66,6 +66,6 @@ lr_schedulers:
 policies:
   - lr_scheduler:
       instance_name: training_lr
-    starting_epoch: 45
+    starting_epoch: 0
     ending_epoch: 300
     frequency: 1

--- a/examples/ssl/ssl_filter-removal_training.yaml
+++ b/examples/ssl/ssl_filter-removal_training.yaml
@@ -9,7 +9,7 @@
 # time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.3 --epochs=180 --compress=../ssl/ssl_filter-removal_training.yaml -j=1 --deterministic --name="filters"
 #
 # To fine-tune:
-# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.2 --epochs=98 --compress=../ssl/ssl_channels-removal_finetuning.yaml -j=1 --deterministic --resume=...
+# time python3 compress_classifier.py --arch resnet20_cifar  ../../../data.cifar10 -p=50 --lr=0.2 --epochs=98 --compress=../ssl/ssl_channels-removal_finetuning.yaml --reset-optimizer --resume-from=...
 #
 # Parameters:
 # +----+-------------------------------------+----------------+---------------+----------------+------------+------------+----------+----------+----------+------------+---------+----------+------------+

--- a/examples/ssl/vgg16_cifar_ssl_channels_training.yaml
+++ b/examples/ssl/vgg16_cifar_ssl_channels_training.yaml
@@ -5,7 +5,7 @@
 # time python3 compress_classifier.py --arch vgg16_cifar  ../../../data.cifar10 -p=50 --lr=0.05 --epochs=180 --compress=../ssl/vgg16_cifar_ssl_channels_training.yaml -j=1 --deterministic
 #
 # The results below are from the SSL training session, and you can follow-up with some fine-tuning:
-# time python3 compress_classifier.py --arch vgg16_cifar  ../../../data.cifar10 --resume=checkpoint.vgg16_cifar.pth.tar --lr=0.01 --epochs=20
+# time python3 compress_classifier.py --arch vgg16_cifar  ../../../data.cifar10 --resume-from=checkpoint.vgg16_cifar.pth.tar  --reset-optimizer --lr=0.01 --epochs=20
 # ==> Top1: 91.010    Top5: 99.480    Loss: 0.513
 #
 # Parameters:
@@ -74,14 +74,13 @@ extensions:
 policies:
   - lr_scheduler:
       instance_name: training_lr
-    starting_epoch: 45
+    starting_epoch: 0
     ending_epoch: 300
     frequency: 1
 
-# After completeing the regularization, we perform network thinning and exit.
   - extension:
       instance_name: net_thinner
-    epochs: [179]
+    epochs: [0]
 
   - regularizer:
       instance_name: Channels_groups_regularizer

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -133,11 +133,8 @@ def test_load_gpu_model_on_cpu_lean_checkpoint():
     checkpoint_filename = '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar'
 
     model = create_model(False, 'cifar10', 'resnet20_cifar', device_ids=CPU_DEVICE_ID)
-    model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
-        model, checkpoint_filename, model_device=CPU_DEVICE_NAME, lean_checkpoint=True)
-
-    assert compression_scheduler is None
-    assert optimizer is None
+    model = load_lean_checkpoint(model, checkpoint_filename,
+                                 model_device=CPU_DEVICE_NAME)
     assert distiller.model_device(model) == CPU_DEVICE_NAME
 
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -15,7 +15,6 @@
 #
 import logging
 import os
-import pickle
 import sys
 import tempfile
 
@@ -47,15 +46,15 @@ def test_load():
     logger.setLevel(logging.INFO)
 
     checkpoint_filename = 'checkpoints/resnet20_cifar10_checkpoint.pth.tar'
-    src_optimizer = pickle.loads(torch.load(checkpoint_filename)['optimizer'])
+    src_optimizer_state_dict = torch.load(checkpoint_filename)['optimizer_state_dict']
 
     model = create_model(False, 'cifar10', 'resnet20_cifar', 0)
     model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
         model, checkpoint_filename)
     assert compression_scheduler is not None
     assert optimizer is not None, 'Failed to load the optimizer'
-    if not _is_similar_param_groups(src_optimizer.state_dict(), optimizer.state_dict()):
-        assert src_optimizer == optimizer.state_dict() # this will always fail
+    if not _is_similar_param_groups(src_optimizer_state_dict, optimizer.state_dict()):
+        assert src_optimizer_state_dict == optimizer.state_dict() # this will always fail
     assert start_epoch == 1
 
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -113,29 +113,32 @@ def test_load_negative():
 def test_load_gpu_model_on_cpu():
     # Issue #148
     CPU_DEVICE_ID = -1
-    checkpoint_filename = '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar'
+    CPU_DEVICE_NAME = 'cpu'
+    checkpoint_filename = 'checkpoints/resnet20_cifar10_checkpoint.pth.tar'
 
     model = create_model(False, 'cifar10', 'resnet20_cifar', device_ids=CPU_DEVICE_ID)
     model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
         model, checkpoint_filename)
 
     assert compression_scheduler is not None
-    assert optimizer is None
-    assert start_epoch == 180
-    assert distiller.model_device(model) == 'cpu'
+    assert optimizer is not None
+    assert distiller.utils.optimizer_device_name(optimizer) == CPU_DEVICE_NAME
+    assert start_epoch == 1
+    assert distiller.model_device(model) == CPU_DEVICE_NAME
 
 
 def test_load_gpu_model_on_cpu_lean_checkpoint():
     CPU_DEVICE_ID = -1
+    CPU_DEVICE_NAME = 'cpu'
     checkpoint_filename = '../examples/ssl/checkpoints/checkpoint_trained_dense.pth.tar'
 
     model = create_model(False, 'cifar10', 'resnet20_cifar', device_ids=CPU_DEVICE_ID)
     model, compression_scheduler, optimizer, start_epoch = load_checkpoint(
-        model, checkpoint_filename, lean_checkpoint=True)
+        model, checkpoint_filename, model_device=CPU_DEVICE_NAME, lean_checkpoint=True)
 
     assert compression_scheduler is None
     assert optimizer is None
-    assert distiller.model_device(model) == 'cpu'
+    assert distiller.model_device(model) == CPU_DEVICE_NAME
 
 
 def test_load_gpu_model_on_cpu_with_thinning():

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -23,7 +23,7 @@ import distiller
 import common
 import pytest
 from distiller.models import create_model
-from distiller.apputils import save_checkpoint, load_checkpoint
+from distiller.apputils import save_checkpoint, load_checkpoint, load_lean_checkpoint
 
 # Logging configuration
 logging.basicConfig(level=logging.INFO)
@@ -296,7 +296,7 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
     conv2 = common.find_module_by_name(model_2, pair[1])
     assert conv2 is not None
     with pytest.raises(KeyError):
-        model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+        model_2 = load_lean_checkpoint(model_2, 'checkpoint.pth.tar')
     compression_scheduler = distiller.CompressionScheduler(model)
     hasattr(model, 'thinning_recipes')
 
@@ -304,13 +304,13 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
 
     # (2)
     save_checkpoint(epoch=0, arch=config.arch, model=model, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2 = load_lean_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done")
 
     # (3)
     save_checkpoint(epoch=0, arch=config.arch, model=model_2, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2 = load_lean_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done 2")
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -296,7 +296,7 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
     conv2 = common.find_module_by_name(model_2, pair[1])
     assert conv2 is not None
     with pytest.raises(KeyError):
-        model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+        model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     compression_scheduler = distiller.CompressionScheduler(model)
     hasattr(model, 'thinning_recipes')
 
@@ -304,13 +304,13 @@ def arbitrary_channel_pruning(config, channels_to_remove, is_parallel):
 
     # (2)
     save_checkpoint(epoch=0, arch=config.arch, model=model, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done")
 
     # (3)
     save_checkpoint(epoch=0, arch=config.arch, model=model_2, optimizer=None, scheduler=compression_scheduler)
-    model_2, compression_scheduler, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
+    model_2, compression_scheduler, optimizer, start_epoch = load_checkpoint(model_2, 'checkpoint.pth.tar')
     assert hasattr(model_2, 'thinning_recipes')
     logger.info("test_arbitrary_channel_pruning - Done 2")
 


### PR DESCRIPTION
[ resubmitting #169 ]

This fixes long-standing bug in distiller with resuming from checkpoint.
Before this patch, the optimizer field in the checkpoint was ignored.

Although it corrects an erroneous behavior of the 'resume' flag, it is a behavioral change of dominant functionality.

A few thoughts before merging into master:

Documentation: This patch does not contain required changes to Distiller online documentation.
Insufficient tests: None of current tests caught that bug, nor I address this matter in my patch.
I tested it briefly with the attached steplr lr_sched recipe, and enjoyed using it, but don't trust me on this - test for yourself. I have no idea how it plays with quantization, gpu<-->cpu transitions, or non-sgd optimizers.
examples change: In the patch I added a flag that effectively reverts to the old incorrect behavior, but I didn't revise the examples in distiller.
I assume there's no example-file or notebook in Distiller that intentionally tries to take advantage of this bug.
with post-training pruning in mind - when one resumes local distiller checkpoint in order to prune it, it contains the old optimizer, and therefore what he probably expects is old behavior. This can be achieved with the 'reset-lr'/'reset-optimizer' flag. Using '--pretrained' without resume is not affected.

Please review, validate, test, and then merge with caution.