### PR TITLE
Fix typo in tflogger path

### DIFF
--- a/examples/automated_deep_compression/ADC.py
+++ b/examples/automated_deep_compression/ADC.py
@@ -618,7 +618,7 @@ class DistillerWrapperEnvironment(gym.Env):
         msglogger.info("self._removed_macs={}".format(self._removed_macs))
         assert math.isclose(layer_macs_after_action / layer_macs, 1 - pruning_action)
 
-        stats = ('Peformance/Validation/',
+        stats = ('Performance/Validation/',
                  OrderedDict([('requested_action', pruning_action)]))
 
         distiller.log_training_progress(stats, None,
@@ -761,7 +761,7 @@ class DistillerWrapperEnvironment(gym.Env):
             msglogger.info("Total parameters left: %.2f%%" % (compression*100))
             msglogger.info("Total compute left: %.2f%%" % (total_macs/self.dense_model_macs*100))
 
-            stats = ('Peformance/EpisodeEnd/',
+            stats = ('Performance/EpisodeEnd/',
                      OrderedDict([('Loss', vloss),
                                   ('Top1', top1),
                                   ('Top5', top5),

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -269,7 +269,7 @@ def main():
                                                 collector=collectors["sparsity"])
             save_collectors_data(collectors, msglogger.logdir)
 
-        stats = ('Peformance/Validation/',
+        stats = ('Performance/Validation/',
                  OrderedDict([('Loss', vloss),
                               ('Top1', top1),
                               ('Top5', top5)]))
@@ -388,7 +388,7 @@ def train(train_loader, model, criterion, optimizer, epoch,
             stats_dict.update(errs)
             stats_dict['LR'] = optimizer.param_groups[0]['lr']
             stats_dict['Time'] = batch_time.mean
-            stats = ('Peformance/Training/', stats_dict)
+            stats = ('Performance/Training/', stats_dict)
 
             params = model.named_parameters() if args.log_params_histograms else None
             distiller.log_training_progress(stats,

--- a/examples/word_language_model/main.py
+++ b/examples/word_language_model/main.py
@@ -257,7 +257,7 @@ def train(epoch, optimizer, compression_scheduler=None):
                 elapsed * 1000 / args.log_interval, cur_loss, math.exp(cur_loss)))
             total_loss = 0
             start_time = time.time()
-            stats = ('Peformance/Training/',
+            stats = ('Performance/Training/',
                 OrderedDict([
                     ('Loss', cur_loss),
                     ('Perplexity', math.exp(cur_loss)),
@@ -335,7 +335,7 @@ try:
 
         distiller.log_weights_sparsity(model, epoch, loggers=[tflogger, pylogger])
 
-        stats = ('Peformance/Validation/',
+        stats = ('Performance/Validation/',
             OrderedDict([
                 ('Loss', val_loss),
                 ('Perplexity', math.exp(val_loss))]))


### PR DESCRIPTION
"Peformance" --> "Performance"

caution: It has significant visual effect. That will mess things up a bit for you, should you try to compare plots of training sessions made prior to this patch, with new ones.