### PR TITLE
Deterministic test loader

### DIFF
--- a/distiller/apputils/data_loaders.py
+++ b/distiller/apputils/data_loaders.py
@@ -218,7 +218,7 @@ def get_data_loaders(datasets_fn, data_dir, batch_size, num_workers, validation_
     test_sampler = SwitchingSubsetRandomSampler(test_indices, effective_test_size)
     test_loader = torch.utils.data.DataLoader(test_dataset,
                                               batch_size=batch_size, sampler=test_sampler,
-                                              num_workers=min(num_workers, 1), pin_memory=True)
+                                              num_workers=num_workers, pin_memory=True)
 
     input_shape = __image_size(train_dataset)
 

--- a/distiller/apputils/data_loaders.py
+++ b/distiller/apputils/data_loaders.py
@@ -19,12 +19,18 @@
 This code will help with the image classification datasets: ImageNet and CIFAR10
 
 """
+import logging
 import os
 import torch
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 from torch.utils.data.sampler import Sampler
 import numpy as np
+
+import distiller
+
+
+msglogger = logging.getLogger()
 
 DATASETS_NAMES = ['imagenet', 'cifar10']
 
@@ -170,7 +176,18 @@ def get_data_loaders(datasets_fn, data_dir, batch_size, num_workers, validation_
                      effective_train_size=1., effective_valid_size=1., effective_test_size=1.):
     train_dataset, test_dataset = datasets_fn(data_dir)
 
-    worker_init_fn = __deterministic_worker_init_fn if deterministic else None
+    worker_init_fn = None
+    if deterministic:
+        distiller.set_deterministic()
+        worker_init_fn = __deterministic_worker_init_fn
+
+        # Experiment reproducibility is sometimes important.  Pete Warden expounded about this
+        # in his blog: https://petewarden.com/2018/03/19/the-machine-learning-reproducibility-crisis/
+        # In Pytorch, support for deterministic execution is still a bit clunky.
+        if num_workers > 1:
+            msglogger.warning('Number of data loader workers is decreased '
+                'to support deterministic execution')
+        num_workers = min(num_workers, 1)
 
     num_train = len(train_dataset)
     indices = list(range(num_train))
@@ -201,7 +218,7 @@ def get_data_loaders(datasets_fn, data_dir, batch_size, num_workers, validation_
     test_sampler = SwitchingSubsetRandomSampler(test_indices, effective_test_size)
     test_loader = torch.utils.data.DataLoader(test_dataset,
                                               batch_size=batch_size, sampler=test_sampler,
-                                              num_workers=num_workers, pin_memory=True)
+                                              num_workers=min(num_workers, 1), pin_memory=True)
 
     input_shape = __image_size(train_dataset)
 

--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -19,16 +19,22 @@
 This module contains various tensor sparsity/density measurement functions, together
 with some random helper functions.
 """
+
+import argparse
+from collections import OrderedDict
+from copy import deepcopy
+import logging
+import operator
+import random
+
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.backends.cudnn as cudnn
-import random
-from copy import deepcopy
 import yaml
-from collections import OrderedDict
-import argparse
-import operator
+
+
+msglogger = logging.getLogger()
 
 
 def model_device(model):
@@ -555,10 +561,12 @@ def make_non_parallel_copy(model):
 
 
 def set_deterministic():
+    msglogger.debug('set_deterministic is called')
     torch.manual_seed(0)
     random.seed(0)
     np.random.seed(0)
     torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
 
 def yaml_ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -99,6 +99,9 @@ def main():
 
     start_epoch = 0
     perf_scores_history = []
+
+    if args.evaluate:
+        args.deterministic = True
     if args.deterministic:
         # Use a well-known seed, for repeatability of experiments
         distiller.set_deterministic()

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -100,11 +100,6 @@ def main():
     start_epoch = 0
     perf_scores_history = []
     if args.deterministic:
-        # Experiment reproducibility is sometimes important.  Pete Warden expounded about this
-        # in his blog: https://petewarden.com/2018/03/19/the-machine-learning-reproducibility-crisis/
-        # In Pytorch, support for deterministic execution is still a bit clunky.
-        if args.workers > 1:
-            raise ValueError('ERROR: Setting --deterministic requires setting --workers/-j to 0 or 1')
         # Use a well-known seed, for repeatability of experiments
         distiller.set_deterministic()
     else:

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -51,7 +51,7 @@ def get_parser():
     parser.add_argument('--resume', default='', type=str, metavar='PATH',
                         help='path to latest checkpoint (default: none)')
     parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
-                        help='evaluate model on validation set')
+                        help='evaluate model on test set')
     parser.add_argument('--pretrained', dest='pretrained', action='store_true',
                         help='use pre-trained model')
     parser.add_argument('--activation-stats', '--act-stats', nargs='+', metavar='PHASE', default=list(),


### PR DESCRIPTION
Pytorch current optimization for dataset loading does not guarantee order, this results in inconsistent accuracy results as I have reported in issue #195 .

Since the expected behavior for a given test-set and weights is to produce consistent results, this patch addresses that essentially by **(1)** passing over Pytorch's optimization for the test loader. (**THIS CHANGE HAS BEEN REVERTED** it will only behave this way during evaluation)
This patch also **(2)** passes the responsibility to set the environment parameters from the user to Distiller.
**(3)** It sets all the required cudnn parameters that Pytorch requires to guarantee determinism.

Please note that this patch will slow down the test loader.