### PR TITLE
(BREAKING) save_checkpoint(): Save dict of user values instead of best_top1

### DIFF
--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -77,8 +77,7 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
     if hasattr(model, 'quantizer_metadata'):
         checkpoint['quantizer_metadata'] = model.quantizer_metadata
 
-    if extras:
-        checkpoint['extras'] = deepcopy(extras)
+    checkpoint['extras'] = deepcopy(extras)
 
     torch.save(checkpoint, fullpath)
     if is_best:
@@ -92,7 +91,7 @@ def load_lean_checkpoint(model, chkpt_file, model_device=None):
 
 def get_contents_table(d):
     def inspect_val(val):
-        if isinstance(val, (int, float, str)):
+        if isinstance(val, (Number, str)):
             return val
         elif isinstance(val, type):
             return val.__name__

--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -26,7 +26,6 @@ from errno import ENOENT
 import logging
 from numbers import Number
 from tabulate import tabulate
-from copy import deepcopy
 import torch
 import distiller
 from distiller.utils import normalize_module_name

--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -77,7 +77,7 @@ def save_checkpoint(epoch, arch, model, optimizer=None, scheduler=None,
     if hasattr(model, 'quantizer_metadata'):
         checkpoint['quantizer_metadata'] = model.quantizer_metadata
 
-    checkpoint['extras'] = deepcopy(extras)
+    checkpoint['extras'] = extras
 
     torch.save(checkpoint, fullpath)
     if is_best:

--- a/distiller/pruning/greedy_filter_pruning.py
+++ b/distiller/pruning/greedy_filter_pruning.py
@@ -296,7 +296,7 @@ def greedy_pruner(pruned_model, app_args, fraction_to_prune, pruning_step, test_
         results = (iteration, prec1, param_name, compute_density, total_macs, densities)
         record_network_details(results)
         scheduler = create_scheduler(pruned_model, zeros_mask_dict)
-        save_checkpoint(0, arch, pruned_model, optimizer=None, best_top1=prec1, scheduler=scheduler,
+        save_checkpoint(0, arch, pruned_model, optimizer=None, scheduler=scheduler, vals_to_save={'top1': prec1},
                         name="greedy__{}__{:.1f}__{:.1f}".format(str(iteration).zfill(3), compute_density*100, prec1),
                         dir=msglogger.logdir)
         del scheduler
@@ -307,6 +307,6 @@ def greedy_pruner(pruned_model, app_args, fraction_to_prune, pruning_step, test_
     prec1, prec5, loss = test_fn(model=pruned_model)
     print(prec1, prec5, loss)
     scheduler = create_scheduler(pruned_model, zeros_mask_dict)
-    save_checkpoint(0, arch, pruned_model, optimizer=None, best_top1=prec1, scheduler=scheduler,
+    save_checkpoint(0, arch, pruned_model, optimizer=None, scheduler=scheduler, vals_to_save={'top1': prec1},
                     name='_'.join(("greedy", str(fraction_to_prune))),
                     dir=msglogger.logdir)

--- a/distiller/pruning/greedy_filter_pruning.py
+++ b/distiller/pruning/greedy_filter_pruning.py
@@ -296,7 +296,7 @@ def greedy_pruner(pruned_model, app_args, fraction_to_prune, pruning_step, test_
         results = (iteration, prec1, param_name, compute_density, total_macs, densities)
         record_network_details(results)
         scheduler = create_scheduler(pruned_model, zeros_mask_dict)
-        save_checkpoint(0, arch, pruned_model, optimizer=None, scheduler=scheduler, vals_to_save={'top1': prec1},
+        save_checkpoint(0, arch, pruned_model, optimizer=None, scheduler=scheduler, extras={'top1': prec1},
                         name="greedy__{}__{:.1f}__{:.1f}".format(str(iteration).zfill(3), compute_density*100, prec1),
                         dir=msglogger.logdir)
         del scheduler
@@ -307,6 +307,6 @@ def greedy_pruner(pruned_model, app_args, fraction_to_prune, pruning_step, test_
     prec1, prec5, loss = test_fn(model=pruned_model)
     print(prec1, prec5, loss)
     scheduler = create_scheduler(pruned_model, zeros_mask_dict)
-    save_checkpoint(0, arch, pruned_model, optimizer=None, scheduler=scheduler, vals_to_save={'top1': prec1},
+    save_checkpoint(0, arch, pruned_model, optimizer=None, scheduler=scheduler, extras={'top1': prec1},
                     name='_'.join(("greedy", str(fraction_to_prune))),
                     dir=msglogger.logdir)

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -240,10 +240,12 @@ def main():
 
     if args.thinnify:
         #zeros_mask_dict = distiller.create_model_masks_dict(model)
-        assert args.resumed_checkpoint_path is not None, "You must use --resume-from to provide a checkpoint file to thinnify"
+        assert args.resumed_checkpoint_path is not None, \
+            "You must use --resume-from to provide a checkpoint file to thinnify"
         distiller.remove_filters(model, compression_scheduler.zeros_mask_dict, args.arch, args.dataset, optimizer=None)
         apputils.save_checkpoint(0, args.arch, model, optimizer=None, scheduler=compression_scheduler,
-                                 name="{}_thinned".format(args.resumed_checkpoint_path.replace(".pth.tar", "")), dir=msglogger.logdir)
+                                 name="{}_thinned".format(args.resumed_checkpoint_path.replace(".pth.tar", "")),
+                                 dir=msglogger.logdir)
         print("Note: your model may have collapsed to random inference, so you may want to fine-tune")
         return
 
@@ -306,8 +308,11 @@ def main():
         # Update the list of top scores achieved so far, and save the checkpoint
         update_training_scores_history(perf_scores_history, model, top1, top5, epoch, args.num_best_scores)
         is_best = epoch == perf_scores_history[0].epoch
-        apputils.save_checkpoint(epoch, args.arch, model, optimizer, compression_scheduler,
-                                 perf_scores_history[0].top1, is_best, args.name, msglogger.logdir)
+        vals_to_save = {'current_top1': top1,
+                        'best_top1': perf_scores_history[0].top1,
+                        'best_epoch': perf_scores_history[0].epoch}
+        apputils.save_checkpoint(epoch, args.arch, model, optimizer=optimizer, scheduler=compression_scheduler,
+                                 vals_to_save=vals_to_save, is_best=is_best, name=args.name, dir=msglogger.logdir)
 
     # Finally run results on the test set
     test(test_loader, model, criterion, [pylogger], activations_collectors, args=args)
@@ -637,9 +642,9 @@ def evaluate_model(model, criterion, test_loader, loggers, activations_collector
 
     if args.quantize_eval:
         checkpoint_name = 'quantized'
-        apputils.save_checkpoint(0, args.arch, model, optimizer=None, best_top1=top1, scheduler=scheduler,
+        apputils.save_checkpoint(0, args.arch, model, optimizer=None, scheduler=scheduler,
                                  name='_'.join([args.name, checkpoint_name]) if args.name else checkpoint_name,
-                                 dir=msglogger.logdir)
+                                 dir=msglogger.logdir, vals_to_save={'quantized_top1': top1})
 
 
 def summarize_model(model, dataset, which_summary):

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -308,11 +308,11 @@ def main():
         # Update the list of top scores achieved so far, and save the checkpoint
         update_training_scores_history(perf_scores_history, model, top1, top5, epoch, args.num_best_scores)
         is_best = epoch == perf_scores_history[0].epoch
-        vals_to_save = {'current_top1': top1,
-                        'best_top1': perf_scores_history[0].top1,
-                        'best_epoch': perf_scores_history[0].epoch}
+        checkpoint_extras = {'current_top1': top1,
+                             'best_top1': perf_scores_history[0].top1,
+                             'best_epoch': perf_scores_history[0].epoch}
         apputils.save_checkpoint(epoch, args.arch, model, optimizer=optimizer, scheduler=compression_scheduler,
-                                 vals_to_save=vals_to_save, is_best=is_best, name=args.name, dir=msglogger.logdir)
+                                 extras=checkpoint_extras, is_best=is_best, name=args.name, dir=msglogger.logdir)
 
     # Finally run results on the test set
     test(test_loader, model, criterion, [pylogger], activations_collectors, args=args)
@@ -644,7 +644,7 @@ def evaluate_model(model, criterion, test_loader, loggers, activations_collector
         checkpoint_name = 'quantized'
         apputils.save_checkpoint(0, args.arch, model, optimizer=None, scheduler=scheduler,
                                  name='_'.join([args.name, checkpoint_name]) if args.name else checkpoint_name,
-                                 dir=msglogger.logdir, vals_to_save={'quantized_top1': top1})
+                                 dir=msglogger.logdir, extras={'quantized_top1': top1})
 
 
 def summarize_model(model, dataset, which_summary):


### PR DESCRIPTION
'best_top1' is too specific to classification workloads. Suggesting to just pass a dictionary of values instead, which will allow to pass anything the user deems worthy.
Also modified `load_checkpoint` to print a summary of the checkpoint contents, it looks something like this:

```
=> loading checkpoint logs/2019.04.04-131231/checkpoint.pth.tar
=> Checkpoint contents:
+----------------------+----------------+
| Key                  | Type / Value   |
|----------------------+----------------|
| arch                 | resnet20_cifar |
| best_epoch           | 1              |
| best_top1            | 58.06          |
| compression_sched    | dict           |
| current_top1         | 53.18          |
| epoch                | 2              |
| optimizer_state_dict | dict           |
| optimizer_type       | SGD            |
| state_dict           | OrderedDict    |
+----------------------+----------------+
```

For "simple" values it'll print the actual value, otherwise it prints the type.