### PR TITLE
Fix issue #213

### DIFF
--- a/distiller/summary_graph.py
+++ b/distiller/summary_graph.py
@@ -43,7 +43,7 @@ def onnx_name_2_pytorch_name(name, op_type):
     #   x = x.view(...)
     #   x = F.relu(x)
     # In this case, to have a meaningful name, we use the op type
-    new_name = ('.'.join(name_parts) if len(name_parts) > 0 else op_type) + "." + instance
+    new_name = ('.'.join(name_parts) if len(name_parts) > 0 else op_type) + instance
 
     msglogger.debug("new sgraph node {} {} {}".format(name, op_type, new_name))
     return new_name

--- a/tests/test_summarygraph.py
+++ b/tests/test_summarygraph.py
@@ -59,7 +59,7 @@ def test_connectivity():
     assert g is not None
 
     op_names = [op['name'] for op in g.ops.values()]
-    assert 80 == len(op_names)
+    assert 81 == len(op_names)
 
     edges = g.edges
     assert edges[0].src == '0' and edges[0].dst == 'conv1'
@@ -173,10 +173,10 @@ def test_connectivity_summary():
     assert g is not None
 
     summary = connectivity_summary(g)
-    assert len(summary) == 80
+    assert len(summary) == 81
 
     verbose_summary = connectivity_summary_verbose(g)
-    assert len(verbose_summary) == 80
+    assert len(verbose_summary) == 81
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes issue #213.

Dropout layers were not handled properly in SummaryGraph, and
caused the indexing of layer names to change.
The root cause is that in ONNX node names are composed of (roughly)
three parts: the node name, type, and instance.
In SummaryGraph we ignore the node type when naming a node.
Specifically in AlexNet, nodes the Dropout layers before a Linear
layer have the same node name and instance, and are only distinguished
by their type.  SummaryGraph, ignorant of the type, skipped the Dropout
layers and gave nodes the wrong name.  Thus 'classifier.0', which is
a Dropout node, became a Linear node.
The fix is not to ignore duplicate (node name, instance) pairs
by incrementing the instance.