### PR TITLE
Log "pip freeze"

### DIFF
--- a/distiller/apputils/execution_env.py
+++ b/distiller/apputils/execution_env.py
@@ -22,11 +22,13 @@ you want to understand the environment in which you execute the training.
 
 import logging
 import logging.config
+import operator
 import os
 import platform
 import shutil
 import sys
 import time
+import pkg_resources
 
 from git import Repo, InvalidGitRepositoryError
 import numpy as np
@@ -83,8 +85,10 @@ def log_execution_env_state(config_paths=None, logdir=None, gitroot='.'):
     if HAVE_LSB:
         logger.debug("OS: %s", lsb_release.get_lsb_information()['DESCRIPTION'])
     logger.debug("Python: %s", sys.version)
-    logger.debug("PyTorch: %s", torch.__version__)
-    logger.debug("Numpy: %s", np.__version__)
+    def _pip_freeze():
+        return {x.key:x.version for x in sorted(pkg_resources.working_set,
+                                                key=operator.attrgetter('key'))}
+    logger.debug("pip freeze: {}".format(_pip_freeze()))
     log_git_state()
     logger.debug("Command line: %s", " ".join(sys.argv))
 


### PR DESCRIPTION
Log all pip packages instead of doing so selectively.
Listing all the packages might sound a bit excessive, but I prefer that over keeping track on each environment variable that might/not affect the user's experience, and statically add it to the logging function.