### PR TITLE
Added support for setting the PRNG seed

### DIFF
--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -602,7 +602,7 @@ def set_seed(seed):
     np.random.seed(seed)
 
 
-def set_deterministic(is_deterministic=True, seed=0):
+def set_deterministic(is_deterministic=True, seed=None):
     '''Try to configure the system for reproducible results.
 
     Experiment reproducibility is sometimes important.  Pete Warden expounded about this

--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -602,7 +602,7 @@ def set_seed(seed):
     np.random.seed(seed)
 
 
-def set_deterministic(seed=None):
+def set_deterministic(seed=0):
     '''Try to configure the system for reproducible results.
 
     Experiment reproducibility is sometimes important.  Pete Warden expounded about this

--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -602,23 +602,19 @@ def set_seed(seed):
     np.random.seed(seed)
 
 
-def set_deterministic(is_deterministic=True, seed=None):
+def set_deterministic(seed=None):
     '''Try to configure the system for reproducible results.
 
     Experiment reproducibility is sometimes important.  Pete Warden expounded about this
     in his blog: https://petewarden.com/2018/03/19/the-machine-learning-reproducibility-crisis/
     For Pytorch specifics see: https://pytorch.org/docs/stable/notes/randomness.html#reproducibility
     '''
-    msglogger.debug("set_deterministic({})".format(is_deterministic))
-    if seed is None and is_deterministic:
+    msglogger.debug('set_deterministic was invoked')
+    if seed is None:
         seed = 0
-    if seed is not None:
-        set_seed(seed)
-    torch.backends.cudnn.deterministic = is_deterministic
-    # Turn on CUDNN benchmark mode for best performance (non-deterministic). This is usually "safe"
-    # for image classification models, as the input sizes don't change during the run
-    # See here: https://discuss.pytorch.org/t/what-does-torch-backends-cudnn-benchmark-do/5936/3
-    torch.backends.cudnn.benchmark = not is_deterministic
+    set_seed(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
 
 def yaml_ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -104,7 +104,15 @@ def main():
 
     if args.evaluate:
         args.deterministic = True
-    distiller.set_deterministic(args.deterministic, args.seed)
+    if args.deterministic:
+        distiller.set_deterministic(args.seed) # For experiment reproducability
+    else:
+        if args.seed is not None:
+            distiller.set_seed(args.seed)
+        # Turn on CUDNN benchmark mode for best performance. This is usually "safe" for image
+        # classification models, as the input sizes don't change during the run
+        # See here: https://discuss.pytorch.org/t/what-does-torch-backends-cudnn-benchmark-do/5936/3
+        cudnn.benchmark = True
 
     start_epoch = 0
     ending_epoch = args.epochs

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -102,21 +102,13 @@ def main():
         msglogger.logdir, gitroot=module_path)
     msglogger.debug("Distiller: %s", distiller.__version__)
 
+    if args.evaluate:
+        args.deterministic = True
+    distiller.set_deterministic(args.deterministic, args.seed)
+
     start_epoch = 0
     ending_epoch = args.epochs
     perf_scores_history = []
-
-    if args.evaluate:
-        args.deterministic = True
-    if args.deterministic:
-        # Experiment reproducibility is sometimes important.  Pete Warden expounded about this
-        # in his blog: https://petewarden.com/2018/03/19/the-machine-learning-reproducibility-crisis/
-        distiller.set_deterministic()  # Use a well-known seed, for repeatability of experiments
-    else:
-        # Turn on CUDNN benchmark mode for best performance. This is usually "safe" for image
-        # classification models, as the input sizes don't change during the run
-        # See here: https://discuss.pytorch.org/t/what-does-torch-backends-cudnn-benchmark-do/5936/3
-        cudnn.benchmark = True
 
     if args.cpu or not torch.cuda.is_available():
         # Set GPU index to -1 if using CPU

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -97,6 +97,8 @@ def get_parser():
                         help='file with extra configuration information')
     parser.add_argument('--deterministic', '--det', action='store_true',
                         help='Ensure deterministic execution for re-producible results.')
+    parser.add_argument('--seed', type=int, default=None,
+                        help='seed the PRNG for CPU, CUDA, numpy, and Python')
     parser.add_argument('--gpus', metavar='DEV_ID', default=None,
                         help='Comma-separated list of GPU device IDs to be used (default is to use all available devices)')
     parser.add_argument('--cpu', action='store_true', default=False,


### PR DESCRIPTION
Added set_seed() to Distiller (utils.py) and added support for seeding the PRNG,
in both reproducible and non-reproducible modes.
The PRNGs of Pytorch (CPU & Cuda devices), numpy and Python are set.
Added support for ```--seed``` to classifier_compression.py.