### PR TITLE
DataParallel for QuantAwareTrainRangeLinearQuantizer

### DIFF
--- a/distiller/quantization/range_linear.py
+++ b/distiller/quantization/range_linear.py
@@ -1006,10 +1006,6 @@ class QuantAwareTrainRangeLinearQuantizer(Quantizer):
                                                                   overrides=overrides,
                                                                   train_with_fp_copy=True)
 
-        if isinstance(model, nn.DataParallel) and len(model.device_ids) > 1:
-            raise RuntimeError('QuantAwareTrainRangeLinearQuantizer currently does not support running with '
-                               'multiple GPUs')
-
         mode = verify_quant_mode(mode)
 
         self.model.quantizer_metadata['params']['mode'] = str(mode).split('.')[1]


### PR DESCRIPTION
* Removed RuntimeError when using nn.DataParallel with QuantAwareTrainRangeLinearQuantizer

Training with FakeLinearQuantization using Multi GPU is working after upgrading to PyTorch 1.0.1