### PR TITLE
Bugfix: convert thresholds to weights' dtype

### DIFF
--- a/distiller/thresholding.py
+++ b/distiller/thresholding.py
@@ -184,6 +184,7 @@ def group_threshold_mask(param, group_type, threshold, threshold_criteria, binar
 def threshold_policy(weights, thresholds, threshold_criteria, dim=1):
     """
     """
+    thresholds = thresholds.type(weights.type())
     if threshold_criteria in ['Mean_Abs', 'Mean_L1']:
         return weights.data.norm(p=1, dim=dim).div(weights.size(dim)).gt(thresholds).type(weights.type())
     if threshold_criteria == 'Mean_L2':

--- a/tests/test_thresholding.py
+++ b/tests/test_thresholding.py
@@ -26,26 +26,29 @@ def get_test_tensor():
 
 
 def test_row_thresholding():
-    p = get_test_tensor().cuda()
-    group_th = distiller.GroupThresholdMixin()
-    mask = group_th.group_threshold_mask(p, 'Rows', 7, 'Max')
-    assert torch.eq(mask, torch.tensor([[ 0.,  0.,  0.],
-                                        [ 0.,  0.,  0.],
-                                        [ 1.,  1.,  1.],
-                                        [ 1.,  1.,  1.]], device=mask.device)).all()
+    for dtype in [torch.float16, torch.float32]:
+        p = get_test_tensor().type(dtype).cuda()
+        group_th = distiller.GroupThresholdMixin()
+        mask = group_th.group_threshold_mask(p, 'Rows', 7, 'Max')
+        assert torch.eq(mask, torch.tensor([[ 0.,  0.,  0.],
+                                            [ 0.,  0.,  0.],
+                                            [ 1.,  1.,  1.],
+                                            [ 1.,  1.,  1.]], device=mask.device).type(dtype)).all()
     return mask
 
 
 def test_col_thresholding():
-    p = get_test_tensor().cuda()
-    group_th = distiller.GroupThresholdMixin()
-    mask = group_th.group_threshold_mask(p, 'Cols', 11, 'Max')
-    assert torch.eq(mask, torch.tensor([[ 0.,  0.,  1.],
-                                        [ 0.,  0.,  1.],
-                                        [ 0.,  0.,  1.],
-                                        [ 0.,  0.,  1.]], device=mask.device)).all()
+    for dtype in [torch.float16, torch.float32]:
+        p = get_test_tensor().type(dtype).cuda()
+        group_th = distiller.GroupThresholdMixin()
+        mask = group_th.group_threshold_mask(p, 'Cols', 11, 'Max')
+        assert torch.eq(mask, torch.tensor([[ 0.,  0.,  1.],
+                                            [ 0.,  0.,  1.],
+                                            [ 0.,  0.,  1.],
+                                            [ 0.,  0.,  1.]], device=mask.device).type(dtype)).all()
     return mask
 
 if __name__ == '__main__':
+    test_row_thresholding()
     m = test_col_thresholding()
     print(m)


### PR DESCRIPTION
This fixes `RuntimeError: Expected object of scalar type Half but got scalar type Float for argument #2 'other'`, e.g. during fp16 training.