### PR TITLE
Allow loading checkpoints with superfluous state-keys

### DIFF
--- a/distiller/apputils/checkpoint.py
+++ b/distiller/apputils/checkpoint.py
@@ -172,8 +172,8 @@ def load_checkpoint(model, chkpt_file, optimizer=None, model_device=None, *,
         if unexpected_keys:
             msglogger.warning("Warning: the loaded checkpoint (%s) contains %d unexpected state keys" % (chkpt_file, len(unexpected_keys)))
         if missing_keys:
-            msglogger.warning("Warning: the loaded checkpoint (%s) is missing %d state keys" % (chkpt_file, len(missing_keys)))
-
+            raise ValueError("The loaded checkpoint (%s) is missing %d state keys" % (chkpt_file, len(missing_keys)))
+            
     if model_device is not None:
         model.to(model_device)
 

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -146,7 +146,9 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
     light-weight and quicker than collecting a record per activation.
     The statistic function is configured in the constructor.
     """
-    def __init__(self, model, stat_name, summary_fn, classes=[torch.nn.ReLU]):
+    def __init__(self, model, stat_name, summary_fn, classes=[torch.nn.ReLU,
+                                                              torch.nn.ReLU6,
+                                                              torch.nn.LeakyReLU]):
         super(SummaryActivationStatsCollector, self).__init__(model, stat_name, classes)
         self.summary_fn = summary_fn
 

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -146,9 +146,7 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
     light-weight and quicker than collecting a record per activation.
     The statistic function is configured in the constructor.
     """
-    def __init__(self, model, stat_name, summary_fn, classes=[torch.nn.ReLU,
-                                                              torch.nn.ReLU6,
-                                                              torch.nn.LeakyReLU]):
+    def __init__(self, model, stat_name, summary_fn, classes=[torch.nn.ReLU]):
         super(SummaryActivationStatsCollector, self).__init__(model, stat_name, classes)
         self.summary_fn = summary_fn
 


### PR DESCRIPTION
Change the default checkpoint loading behavior, such that we allow
loading a checkpoint that has state-dict entries that do not
appear in the original (Distiller) model.
