### PR TITLE
Increase Tensorflow min version to 1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torchvision==0.3.0
 scipy>=1.3.0
 gitpython==2.1.11
 torchnet==0.0.4
-tensorflow>=1.13
+tensorflow>=1.14
 pydot==1.4.1
 tabulate==0.8.3
 pandas>=0.22.0


### PR DESCRIPTION
tensorboard 1.14 is required to take advantage of Pytorch's exp. implementation of summarywriter.
(It wasn't stable yet when I pushed the Pytorch 1.1 initial commit)