### PR TITLE
DistillerModuleList conversion: Handle models with duplicate modules

### DIFF
--- a/distiller/summary_graph.py
+++ b/distiller/summary_graph.py
@@ -706,6 +706,24 @@ class _DistillerModuleList(object):
         return main_str
 
 
+def _named_children_with_duplicates(module):
+    """Version of torch.nn.Module.named_children() that includes duplicate modules"""
+    for name, module in module._modules.items():
+        if module is not None:
+            yield name, module
+
+
+def _named_modules_with_duplicates(module, prefix=''):
+    """Version of torch.nn.Module.named_modules() that includes duplicate modules"""
+    yield prefix, module
+    for name, submodule in module._modules.items():
+        if submodule is None:
+            continue
+        submodule_prefix = prefix + ('.' if prefix else '') + name
+        for m in _named_modules_with_duplicates(submodule, submodule_prefix):
+            yield m
+
+
 def _to_distiller_modulelist(model):
     """Replaces all instances of torch.nn.ModuleList in a model with DistillerModuleList instances
 
@@ -713,9 +731,11 @@ def _to_distiller_modulelist(model):
         model (torch.nn.Module): Model to convert
     """
     def convert_container(container):
-        named_children = OrderedDict(container.named_children())
         # To maintain a similar order of registered modules compared to the original container, we unregister
         # all modules and then register them again
+        # We take care to include duplicated modules, which are not returned by the original named_moduels/children
+        # implementation in torch.nn.Module
+        named_children = OrderedDict(_named_children_with_duplicates(container))
         for n, _ in named_children.items():
             delattr(container, n)
         for name, child in named_children.items():
@@ -732,9 +752,10 @@ def _to_distiller_modulelist(model):
                     convert_container(m)
         return container
 
-    named_modules_orig = OrderedDict([(n, m) for n, m in model.named_modules() if not isinstance(m, nn.ModuleList)])
+    named_modules_orig = OrderedDict([(n, m) for n, m in _named_modules_with_duplicates(model)
+                                      if not isinstance(m, nn.ModuleList)])
     model = convert_container(model)
-    named_modules_dmlist = OrderedDict(model.named_modules())
+    named_modules_dmlist = OrderedDict(_named_modules_with_duplicates(model))
     converted_module_names_map = OrderedDict(zip(named_modules_dmlist.keys(), named_modules_orig.keys()))
 
     return model, converted_module_names_map


### PR DESCRIPTION
By duplicate modules we mean:
```python
self.relu1 = nn.Relu()
self.relu2 = self.relu1
```
* The issue: The second module ('relu2') will not be returned by `torch.nn.Module.named_modules/children()`
* When converting to DistillerModuleList, in order to maintain the original order of modules and in order to have a correct mapping of names before/after the conversion - we need to take the duplicates into account.
* Implemented an internal version of `named_modules/children` that includes duplicates
* Added test case for this + refactored the module list conversion tests