### PR TITLE
Refactor Image Classifier Distiller Functions

### DIFF
--- a/distiller/__init__.py
+++ b/distiller/__init__.py
@@ -26,6 +26,7 @@ from .policy import *
 from .thinning import *
 from .knowledge_distillation import KnowledgeDistillationPolicy, DistillationLossWeights
 from .summary_graph import SummaryGraph, onnx_name_2_pytorch_name
+import imageclass
 
 import logging
 logging.captureWarnings(True)

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -692,6 +692,7 @@ def collect_quant_stats(model, test_fn, save_dir=None, classes=None, inplace_run
     with collector_context(quant_stats_collector):
         test_fn(model=model)
     msglogger.info('Stats collection complete')
+
     if save_dir is not None:
         save_path = os.path.join(save_dir, 'acts_quantization_stats.yaml')
         quant_stats_collector.save(save_path)

--- a/distiller/quantization/range_linear.py
+++ b/distiller/quantization/range_linear.py
@@ -170,12 +170,11 @@ def add_post_train_quant_args(argparser):
 
     group = argparser.add_argument_group('Arguments controlling quantization at evaluation time '
                                          '("post-training quantization")')
-    exc_group = group.add_mutually_exclusive_group()
-    exc_group.add_argument('--quantize-eval', '--qe', action='store_true',
+    group.add_argument('--quantize-eval', '--qe', action='store_true',
                        help='Apply linear quantization to model before evaluation. Applicable only if '
                             '--evaluate is also set')
-    exc_group.add_argument('--qe-calibration', type=distiller.utils.float_range_argparse_checker(exc_min=True),
-                           metavar='PORTION_OF_TEST_SET',
+    group.add_argument('--qe-calibration', type=distiller.utils.float_range_argparse_checker(exc_min=True),
+                           metavar='PORTION_OF_TEST_SET', default=None,
                            help='Run the model in evaluation mode on the specified portion of the test dataset and '
                                 'collect statistics. Ignores all other \'qe--*\' arguments')
     group.add_argument('--qe-mode', '--qem', type=linear_quant_mode_str, default='sym',

--- a/distiller/utils.py
+++ b/distiller/utils.py
@@ -21,6 +21,7 @@ with some random helper functions.
 """
 import argparse
 from collections import OrderedDict
+import contextlib
 from copy import deepcopy
 import logging
 import operator
@@ -646,6 +647,15 @@ def make_non_parallel_copy(model):
     replace_data_parallel(new_model)
 
     return new_model
+
+
+@contextlib.contextmanager
+def get_nonparallel_clone_model(model):
+    clone_model = make_non_parallel_copy(model)
+    try:
+        yield clone_model
+    finally:
+        del clone_model
 
 
 def set_seed(seed):

--- a/examples/classifier_compression/compress_classifier.py
+++ b/examples/classifier_compression/compress_classifier.py
@@ -27,12 +27,12 @@ is speckled with invocations of CompressionScheduler.
 
 For each epoch:
     compression_scheduler.on_epoch_begin(epoch)
-    train()
+    train_one_epoch()
     validate()
     compression_scheduler.on_epoch_end(epoch)
     save_checkpoint()
 
-train():
+training:
     For each training step:
         compression_scheduler.on_minibatch_begin(epoch)
         output = model(input)
@@ -57,7 +57,7 @@ import os
 import traceback
 import logging
 from collections import OrderedDict
-from functools import partial
+import copy
 import numpy as np
 import torch
 import torch.nn as nn
@@ -65,7 +65,6 @@ import torch.nn.parallel
 import torch.backends.cudnn as cudnn
 import torch.optim
 import torch.utils.data
-import torchnet.meter as tnt
 import distiller
 import distiller.apputils as apputils
 import distiller.model_summaries as model_summaries
@@ -73,8 +72,9 @@ from distiller.data_loggers import *
 import distiller.quantization as quantization
 import examples.automated_deep_compression as adc
 from distiller.models import ALL_MODEL_NAMES, create_model
+from distiller import imageclass
+from imageclass import *
 import parser
-import operator
 
 
 # Logger handle
@@ -209,7 +209,10 @@ def main():
             args.dataset, add_softmax=True, verbose=False)
 
     if args.qe_calibration:
-        return acts_quant_stats_collection(model, criterion, pylogger, args)
+        args_copy = copy.deepcopy(args)
+        args_copy.effective_test_size = args.qe_calibration
+        return acts_quant_stats_collection(load_data(args_copy)[2], model, criterion, pylogger,
+                                           args_copy, save_to_file=True)
 
     if args.activation_histograms:
         return acts_histogram_collection(model, criterion, pylogger, args)
@@ -228,7 +231,7 @@ def main():
         return sensitivity_analysis(model, criterion, test_loader, pylogger, args, sensitivities)
 
     if args.evaluate:
-        return evaluate_model(model, criterion, test_loader, pylogger, activations_collectors, args,
+        return evaluate_model(test_loader, model, criterion, pylogger, activations_collectors, args,
                               compression_scheduler)
 
     if args.compress:
@@ -282,7 +285,7 @@ def main():
 
         # Train for one epoch
         with collectors_context(activations_collectors["train"]) as collectors:
-            train(train_loader, model, criterion, optimizer, epoch, compression_scheduler,
+            train_one_epoch(train_loader, model, criterion, optimizer, epoch, compression_scheduler,
                   loggers=[tflogger, pylogger], args=args)
             distiller.log_weights_sparsity(model, epoch, loggers=[tflogger, pylogger])
             distiller.log_activation_statsitics(epoch, "train", loggers=[tflogger],
@@ -320,313 +323,7 @@ def main():
     test(test_loader, model, criterion, [pylogger], activations_collectors, args=args)
 
 
-OVERALL_LOSS_KEY = 'Overall Loss'
-OBJECTIVE_LOSS_KEY = 'Objective Loss'
-
-
-def train(train_loader, model, criterion, optimizer, epoch,
-          compression_scheduler, loggers, args):
-    """Training loop for one epoch."""
-    losses = OrderedDict([(OVERALL_LOSS_KEY, tnt.AverageValueMeter()),
-                          (OBJECTIVE_LOSS_KEY, tnt.AverageValueMeter())])
-
-    classerr = tnt.ClassErrorMeter(accuracy=True, topk=(1, 5))
-    batch_time = tnt.AverageValueMeter()
-    data_time = tnt.AverageValueMeter()
-
-    # For Early Exit, we define statistics for each exit
-    # So exiterrors is analogous to classerr for the non-Early Exit case
-    if args.earlyexit_lossweights:
-        args.exiterrors = []
-        for exitnum in range(args.num_exits):
-            args.exiterrors.append(tnt.ClassErrorMeter(accuracy=True, topk=(1, 5)))
-
-    total_samples = len(train_loader.sampler)
-    batch_size = train_loader.batch_size
-    steps_per_epoch = math.ceil(total_samples / batch_size)
-    msglogger.info('Training epoch: %d samples (%d per mini-batch)', total_samples, batch_size)
-
-    # Switch to train mode
-    model.train()
-    acc_stats = []
-    end = time.time()
-    for train_step, (inputs, target) in enumerate(train_loader):
-        # Measure data loading time
-        data_time.add(time.time() - end)
-        inputs, target = inputs.to(args.device), target.to(args.device)
-
-        # Execute the forward phase, compute the output and measure loss
-        if compression_scheduler:
-            compression_scheduler.on_minibatch_begin(epoch, train_step, steps_per_epoch, optimizer)
-
-        if not hasattr(args, 'kd_policy') or args.kd_policy is None:
-            output = model(inputs)
-        else:
-            output = args.kd_policy.forward(inputs)
-
-        if not args.earlyexit_lossweights:
-            loss = criterion(output, target)
-            # Measure accuracy
-            classerr.add(output.data, target)
-            acc_stats.append([classerr.value(1), classerr.value(5)])
-        else:
-            # Measure accuracy and record loss
-            loss = earlyexit_loss(output, target, criterion, args)
-        # Record loss
-        losses[OBJECTIVE_LOSS_KEY].add(loss.item())
-
-        if compression_scheduler:
-            # Before running the backward phase, we allow the scheduler to modify the loss
-            # (e.g. add regularization loss)
-            agg_loss = compression_scheduler.before_backward_pass(epoch, train_step, steps_per_epoch, loss,
-                                                                  optimizer=optimizer, return_loss_components=True)
-            loss = agg_loss.overall_loss
-            losses[OVERALL_LOSS_KEY].add(loss.item())
-
-            for lc in agg_loss.loss_components:
-                if lc.name not in losses:
-                    losses[lc.name] = tnt.AverageValueMeter()
-                losses[lc.name].add(lc.value.item())
-        else:
-            losses[OVERALL_LOSS_KEY].add(loss.item())
-
-        # Compute the gradient and do SGD step
-        optimizer.zero_grad()
-        loss.backward()
-        if compression_scheduler:
-            compression_scheduler.before_parameter_optimization(epoch, train_step, steps_per_epoch, optimizer)
-        optimizer.step()
-        if compression_scheduler:
-            compression_scheduler.on_minibatch_end(epoch, train_step, steps_per_epoch, optimizer)
-
-        # measure elapsed time
-        batch_time.add(time.time() - end)
-        steps_completed = (train_step+1)
-
-        if steps_completed % args.print_freq == 0:
-            # Log some statistics
-            errs = OrderedDict()
-            if not args.earlyexit_lossweights:
-                errs['Top1'] = classerr.value(1)
-                errs['Top5'] = classerr.value(5)
-            else:
-                # for Early Exit case, the Top1 and Top5 stats are computed for each exit.
-                for exitnum in range(args.num_exits):
-                    errs['Top1_exit' + str(exitnum)] = args.exiterrors[exitnum].value(1)
-                    errs['Top5_exit' + str(exitnum)] = args.exiterrors[exitnum].value(5)
-
-            stats_dict = OrderedDict()
-            for loss_name, meter in losses.items():
-                stats_dict[loss_name] = meter.mean
-            stats_dict.update(errs)
-            stats_dict['LR'] = optimizer.param_groups[0]['lr']
-            stats_dict['Time'] = batch_time.mean
-            stats = ('Performance/Training/', stats_dict)
-
-            params = model.named_parameters() if args.log_params_histograms else None
-            distiller.log_training_progress(stats,
-                                            params,
-                                            epoch, steps_completed,
-                                            steps_per_epoch, args.print_freq,
-                                            loggers)
-        end = time.time()
-    return acc_stats
-
-
-def validate(val_loader, model, criterion, loggers, args, epoch=-1):
-    """Model validation"""
-    if epoch > -1:
-        msglogger.info('--- validate (epoch=%d)-----------', epoch)
-    else:
-        msglogger.info('--- validate ---------------------')
-    return _validate(val_loader, model, criterion, loggers, args, epoch)
-
-
-def test(test_loader, model, criterion, loggers, activations_collectors, args):
-    """Model Test"""
-    msglogger.info('--- test ---------------------')
-    if activations_collectors is None:
-        activations_collectors = create_activation_stats_collectors(model, None)
-    with collectors_context(activations_collectors["test"]) as collectors:
-        top1, top5, lossses = _validate(test_loader, model, criterion, loggers, args)
-        distiller.log_activation_statsitics(-1, "test", loggers, collector=collectors['sparsity'])
-        save_collectors_data(collectors, msglogger.logdir)
-    return top1, top5, lossses
-
-
-def _validate(data_loader, model, criterion, loggers, args, epoch=-1):
-    """Execute the validation/test loop."""
-    losses = {'objective_loss': tnt.AverageValueMeter()}
-    classerr = tnt.ClassErrorMeter(accuracy=True, topk=(1, 5))
-
-    if args.earlyexit_thresholds:
-        # for Early Exit, we have a list of errors and losses for each of the exits.
-        args.exiterrors = []
-        args.losses_exits = []
-        for exitnum in range(args.num_exits):
-            args.exiterrors.append(tnt.ClassErrorMeter(accuracy=True, topk=(1, 5)))
-            args.losses_exits.append(tnt.AverageValueMeter())
-        args.exit_taken = [0] * args.num_exits
-
-    batch_time = tnt.AverageValueMeter()
-    total_samples = len(data_loader.sampler)
-    batch_size = data_loader.batch_size
-    if args.display_confusion:
-        confusion = tnt.ConfusionMeter(args.num_classes)
-    total_steps = total_samples / batch_size
-    msglogger.info('%d samples (%d per mini-batch)', total_samples, batch_size)
-
-    # Switch to evaluation mode
-    model.eval()
-
-    end = time.time()
-    for validation_step, (inputs, target) in enumerate(data_loader):
-        with torch.no_grad():
-            inputs, target = inputs.to(args.device), target.to(args.device)
-            # compute output from model
-            output = model(inputs)
-
-            if not args.earlyexit_thresholds:
-                # compute loss
-                loss = criterion(output, target)
-                # measure accuracy and record loss
-                losses['objective_loss'].add(loss.item())
-                classerr.add(output.data, target)
-                if args.display_confusion:
-                    confusion.add(output.data, target)
-            else:
-                earlyexit_validate_loss(output, target, criterion, args)
-
-            # measure elapsed time
-            batch_time.add(time.time() - end)
-            end = time.time()
-
-            steps_completed = (validation_step+1)
-            if steps_completed % args.print_freq == 0:
-                if not args.earlyexit_thresholds:
-                    stats = ('',
-                            OrderedDict([('Loss', losses['objective_loss'].mean),
-                                         ('Top1', classerr.value(1)),
-                                         ('Top5', classerr.value(5))]))
-                else:
-                    stats_dict = OrderedDict()
-                    stats_dict['Test'] = validation_step
-                    for exitnum in range(args.num_exits):
-                        la_string = 'LossAvg' + str(exitnum)
-                        stats_dict[la_string] = args.losses_exits[exitnum].mean
-                        # Because of the nature of ClassErrorMeter, if an exit is never taken during the batch,
-                        # then accessing the value(k) will cause a divide by zero. So we'll build the OrderedDict
-                        # accordingly and we will not print for an exit error when that exit is never taken.
-                        if args.exit_taken[exitnum]:
-                            t1 = 'Top1_exit' + str(exitnum)
-                            t5 = 'Top5_exit' + str(exitnum)
-                            stats_dict[t1] = args.exiterrors[exitnum].value(1)
-                            stats_dict[t5] = args.exiterrors[exitnum].value(5)
-                    stats = ('Performance/Validation/', stats_dict)
-
-                distiller.log_training_progress(stats, None, epoch, steps_completed,
-                                                total_steps, args.print_freq, loggers)
-    if not args.earlyexit_thresholds:
-        msglogger.info('==> Top1: %.3f    Top5: %.3f    Loss: %.3f\n',
-                       classerr.value()[0], classerr.value()[1], losses['objective_loss'].mean)
-
-        if args.display_confusion:
-            msglogger.info('==> Confusion:\n%s\n', str(confusion.value()))
-        return classerr.value(1), classerr.value(5), losses['objective_loss'].mean
-    else:
-        total_top1, total_top5, losses_exits_stats = earlyexit_validate_stats(args)
-        return total_top1, total_top5, losses_exits_stats[args.num_exits-1]
-
-
-def update_training_scores_history(perf_scores_history, model, top1, top5, epoch, num_best_scores):
-    """ Update the list of top training scores achieved so far, and log the best scores so far"""
-
-    model_sparsity, _, params_nnz_cnt = distiller.model_params_stats(model)
-    perf_scores_history.append(distiller.MutableNamedTuple({'params_nnz_cnt': -params_nnz_cnt,
-                                                            'sparsity': model_sparsity,
-                                                            'top1': top1, 'top5': top5, 'epoch': epoch}))
-    # Keep perf_scores_history sorted from best to worst
-    # Sort by sparsity as main sort key, then sort by top1, top5 and epoch
-    perf_scores_history.sort(key=operator.attrgetter('params_nnz_cnt', 'top1', 'top5', 'epoch'), reverse=True)
-    for score in perf_scores_history[:num_best_scores]:
-        msglogger.info('==> Best [Top1: %.3f   Top5: %.3f   Sparsity:%.2f   Params: %d on epoch: %d]',
-                       score.top1, score.top5, score.sparsity, -score.params_nnz_cnt, score.epoch)
-
-
-def earlyexit_loss(output, target, criterion, args):
-    loss = 0
-    sum_lossweights = 0
-    for exitnum in range(args.num_exits-1):
-        loss += (args.earlyexit_lossweights[exitnum] * criterion(output[exitnum], target))
-        sum_lossweights += args.earlyexit_lossweights[exitnum]
-        args.exiterrors[exitnum].add(output[exitnum].data, target)
-    # handle final exit
-    loss += (1.0 - sum_lossweights) * criterion(output[args.num_exits-1], target)
-    args.exiterrors[args.num_exits-1].add(output[args.num_exits-1].data, target)
-    return loss
-
-
-def earlyexit_validate_loss(output, target, criterion, args):
-    # We need to go through each sample in the batch itself - in other words, we are
-    # not doing batch processing for exit criteria - we do this as though it were batchsize of 1
-    # but with a grouping of samples equal to the batch size.
-    # Note that final group might not be a full batch - so determine actual size.
-    this_batch_size = target.size()[0]
-    earlyexit_validate_criterion = nn.CrossEntropyLoss(reduce=False).to(args.device)
-
-    for exitnum in range(args.num_exits):
-        # calculate losses at each sample separately in the minibatch.
-        args.loss_exits[exitnum] = earlyexit_validate_criterion(output[exitnum], target)
-        # for batch_size > 1, we need to reduce this down to an average over the batch
-        args.losses_exits[exitnum].add(torch.mean(args.loss_exits[exitnum]).cpu())
-
-    for batch_index in range(this_batch_size):
-        earlyexit_taken = False
-        # take the exit using CrossEntropyLoss as confidence measure (lower is more confident)
-        for exitnum in range(args.num_exits - 1):
-            if args.loss_exits[exitnum][batch_index] < args.earlyexit_thresholds[exitnum]:
-                # take the results from early exit since lower than threshold
-                args.exiterrors[exitnum].add(torch.tensor(np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)),
-                                             torch.full([1], target[batch_index], dtype=torch.long))
-                args.exit_taken[exitnum] += 1
-                earlyexit_taken = True
-                break                    # since exit was taken, do not affect the stats of subsequent exits
-        # this sample does not exit early and therefore continues until final exit
-        if not earlyexit_taken:
-            exitnum = args.num_exits - 1
-            args.exiterrors[exitnum].add(torch.tensor(np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)),
-                                         torch.full([1], target[batch_index], dtype=torch.long))
-            args.exit_taken[exitnum] += 1
-
-
-def earlyexit_validate_stats(args):
-    # Print some interesting summary stats for number of data points that could exit early
-    top1k_stats = [0] * args.num_exits
-    top5k_stats = [0] * args.num_exits
-    losses_exits_stats = [0] * args.num_exits
-    sum_exit_stats = 0
-    for exitnum in range(args.num_exits):
-        if args.exit_taken[exitnum]:
-            sum_exit_stats += args.exit_taken[exitnum]
-            msglogger.info("Exit %d: %d", exitnum, args.exit_taken[exitnum])
-            top1k_stats[exitnum] += args.exiterrors[exitnum].value(1)
-            top5k_stats[exitnum] += args.exiterrors[exitnum].value(5)
-            losses_exits_stats[exitnum] += args.losses_exits[exitnum].mean
-    for exitnum in range(args.num_exits):
-        if args.exit_taken[exitnum]:
-            msglogger.info("Percent Early Exit %d: %.3f", exitnum,
-                           (args.exit_taken[exitnum]*100.0) / sum_exit_stats)
-    total_top1 = 0
-    total_top5 = 0
-    for exitnum in range(args.num_exits):
-        total_top1 += (top1k_stats[exitnum] * (args.exit_taken[exitnum] / sum_exit_stats))
-        total_top5 += (top5k_stats[exitnum] * (args.exit_taken[exitnum] / sum_exit_stats))
-        msglogger.info("Accuracy Stats for exit %d: top1 = %.3f, top5 = %.3f", exitnum, top1k_stats[exitnum], top5k_stats[exitnum])
-    msglogger.info("Totals for entire network with early exits: top1 = %.3f, top5 = %.3f", total_top1, total_top5)
-    return total_top1, total_top5, losses_exits_stats
-
-
-def evaluate_model(model, criterion, test_loader, loggers, activations_collectors, args, scheduler=None):
+def evaluate_model(test_loader, model, criterion, loggers, activations_collectors, args, scheduler=None):
     # This sample application can be invoked to evaluate the accuracy of your model on
     # the test dataset.
     # You can optionally quantize the model to 8-bit integer before evaluation.
@@ -636,142 +333,11 @@ def evaluate_model(model, criterion, test_loader, loggers, activations_collector
     if not isinstance(loggers, list):
         loggers = [loggers]
 
-    if args.quantize_eval:
-        model.cpu()
-        quantizer = quantization.PostTrainLinearQuantizer.from_args(model, args)
-        quantizer.prepare_model(distiller.get_dummy_input(input_shape=model.input_shape))
-        model.to(args.device)
-
-    top1, _, _ = test(test_loader, model, criterion, loggers, activations_collectors, args=args)
-
-    if args.quantize_eval:
-        checkpoint_name = 'quantized'
-        apputils.save_checkpoint(0, args.arch, model, optimizer=None, scheduler=scheduler,
-                                 name='_'.join([args.name, checkpoint_name]) if args.name else checkpoint_name,
-                                 dir=msglogger.logdir, extras={'quantized_top1': top1})
-
-
-def sensitivity_analysis(model, criterion, data_loader, loggers, args, sparsities):
-    # This sample application can be invoked to execute Sensitivity Analysis on your
-    # model.  The ouptut is saved to CSV and PNG.
-    msglogger.info("Running sensitivity tests")
-    if not isinstance(loggers, list):
-        loggers = [loggers]
-    test_fnc = partial(test, test_loader=data_loader, criterion=criterion,
-                       loggers=loggers, args=args,
-                       activations_collectors=create_activation_stats_collectors(model))
-    which_params = [param_name for param_name, _ in model.named_parameters()]
-    sensitivity = distiller.perform_sensitivity_analysis(model,
-                                                         net_params=which_params,
-                                                         sparsities=sparsities,
-                                                         test_func=test_fnc,
-                                                         group=args.sensitivity)
-    distiller.sensitivities_to_png(sensitivity, os.path.join(msglogger.logdir, 'sensitivity.png'))
-    distiller.sensitivities_to_csv(sensitivity, os.path.join(msglogger.logdir, 'sensitivity.csv'))
-
-
-def automated_deep_compression(model, criterion, optimizer, loggers, args):
-    train_loader, val_loader, test_loader, _ = load_data(args)
-
-    args.display_confusion = True
-    validate_fn = partial(test, test_loader=test_loader, criterion=criterion,
-                          loggers=loggers, args=args, activations_collectors=None)
-    train_fn = partial(train, train_loader=train_loader, criterion=criterion,
-                       loggers=loggers, args=args)
-
-    save_checkpoint_fn = partial(apputils.save_checkpoint, arch=args.arch, dir=msglogger.logdir)
-    optimizer_data = {'lr': args.lr, 'momentum': args.momentum, 'weight_decay': args.weight_decay}
-    adc.do_adc(model, args, optimizer_data, validate_fn, save_checkpoint_fn, train_fn)
-
-
-def greedy(model, criterion, optimizer, loggers, args):
-    train_loader, val_loader, test_loader, _ = load_data(args)
-
-    test_fn = partial(test, test_loader=test_loader, criterion=criterion,
-                      loggers=loggers, args=args, activations_collectors=None)
-    train_fn = partial(train, train_loader=train_loader, criterion=criterion, args=args)
-    assert args.greedy_target_density is not None
-    distiller.pruning.greedy_filter_pruning.greedy_pruner(model, args,
-                                                          args.greedy_target_density,
-                                                          args.greedy_pruning_step,
-                                                          test_fn, train_fn)
-
-
-def acts_quant_stats_collection(model, criterion, loggers, args):
-    msglogger.info('Collecting quantization calibration stats based on {:.1%} of test dataset'
-                   .format(args.qe_calibration))
-    model = distiller.utils.make_non_parallel_copy(model)
-    args.effective_test_size = args.qe_calibration
-    train_loader, val_loader, test_loader, _ = load_data(args)
-    test_fn = partial(test, test_loader=test_loader, criterion=criterion,
-                      loggers=loggers, args=args, activations_collectors=None)
-    collect_quant_stats(model, test_fn, save_dir=msglogger.logdir,
-                        classes=None, inplace_runtime_check=True, disable_inplace_attrs=True)
-
-
-def acts_histogram_collection(model, criterion, loggers, args):
-    msglogger.info('Collecting activation histograms based on {:.1%} of test dataset'
-                   .format(args.activation_histograms))
-    model = distiller.utils.make_non_parallel_copy(model)
-    args.effective_test_size = args.activation_histograms
-    train_loader, val_loader, test_loader, _ = load_data(args, fixed_subset=True)
-    test_fn = partial(test, test_loader=test_loader, criterion=criterion,
-                      loggers=loggers, args=args, activations_collectors=None)
-    collect_histograms(model, test_fn, save_dir=msglogger.logdir,
-                       classes=None, nbins=2048, save_hist_imgs=True)
-
-
-def load_data(args, fixed_subset=False):
-    return apputils.load_data(args.dataset, os.path.expanduser(args.data), args.batch_size,
-                              args.workers, args.validation_split, args.deterministic,
-                              args.effective_train_size, args.effective_valid_size, args.effective_test_size,
-                              fixed_subset)
-
-
-class missingdict(dict):
-    """This is a little trick to prevent KeyError"""
-    def __missing__(self, key):
-        return None  # note, does *not* set self[key] - we don't want defaultdict's behavior
-
-
-def create_activation_stats_collectors(model, *phases):
-    """Create objects that collect activation statistics.
-
-    This is a utility function that creates two collectors:
-    1. Fine-grade sparsity levels of the activations
-    2. L1-magnitude of each of the activation channels
-
-    Args:
-        model - the model on which we want to collect statistics
-        phases - the statistics collection phases: train, valid, and/or test
-
-    WARNING! Enabling activation statsitics collection will significantly slow down training!
-    """
-    genCollectors = lambda: missingdict({
-        "sparsity":      SummaryActivationStatsCollector(model, "sparsity",
-                                                         lambda t: 100 * distiller.utils.sparsity(t)),
-        "l1_channels":   SummaryActivationStatsCollector(model, "l1_channels",
-                                                         distiller.utils.activation_channels_l1),
-        "apoz_channels": SummaryActivationStatsCollector(model, "apoz_channels",
-                                                         distiller.utils.activation_channels_apoz),
-        "mean_channels": SummaryActivationStatsCollector(model, "mean_channels",
-                                                         distiller.utils.activation_channels_means),
-        "records":       RecordsActivationStatsCollector(model, classes=[torch.nn.Conv2d])
-    })
-
-    return {k: (genCollectors() if k in phases else missingdict())
-            for k in ('train', 'valid', 'test')}
-
-
-def save_collectors_data(collectors, directory):
-    """Utility function that saves all activation statistics to disk.
-
-    File type and format of contents are collector-specific.
-    """
-    for name, collector in collectors.items():
-        msglogger.info('Saving data for collector {}...'.format(name))
-        file_path = collector.save(os.path.join(directory, name))
-        msglogger.info("Saved to {}".format(file_path))
+    if not args.quantize_eval:
+        return test(test_loader, model, criterion, loggers, activations_collectors, args=args)
+    else:
+        return quantize_and_test_model(test_loader, model, criterion, loggers, activations_collectors,
+                                 args=args, scheduler=scheduler, save_flag=True)
 
 
 if __name__ == '__main__':

--- a/imageclass.py
+++ b/imageclass.py
@@ -1,0 +1,495 @@
+import copy
+import math
+import time
+import os
+import traceback
+import logging
+from collections import OrderedDict
+from functools import partial
+import numpy as np
+import operator
+import torch
+import torch.nn as nn
+import torch.nn.parallel
+import torch.backends.cudnn as cudnn
+import torch.optim
+import torch.utils.data
+import torchnet.meter as tnt
+import distiller
+import distiller.apputils as apputils
+import distiller.model_summaries as model_summaries
+from distiller.data_loggers import *
+import distiller.quantization as quantization
+import examples.automated_deep_compression as adc
+from distiller.models import ALL_MODEL_NAMES, create_model
+import parser
+
+msglogger = logging.getLogger()
+
+OVERALL_LOSS_KEY = 'Overall Loss'
+OBJECTIVE_LOSS_KEY = 'Objective Loss'
+
+
+def train_one_epoch(train_loader, model, criterion, optimizer, epoch,
+          compression_scheduler, loggers, args):
+    """Training loop for one epoch."""
+    losses = OrderedDict([(OVERALL_LOSS_KEY, tnt.AverageValueMeter()),
+                          (OBJECTIVE_LOSS_KEY, tnt.AverageValueMeter())])
+
+    classerr = tnt.ClassErrorMeter(accuracy=True, topk=(1, 5))
+    batch_time = tnt.AverageValueMeter()
+    data_time = tnt.AverageValueMeter()
+
+    # For Early Exit, we define statistics for each exit
+    # So exiterrors is analogous to classerr for the non-Early Exit case
+    if args.earlyexit_lossweights:
+        args.exiterrors = []
+        for exitnum in range(args.num_exits):
+            args.exiterrors.append(tnt.ClassErrorMeter(accuracy=True, topk=(1, 5)))
+
+    total_samples = len(train_loader.sampler)
+    batch_size = train_loader.batch_size
+    steps_per_epoch = math.ceil(total_samples / batch_size)
+    msglogger.info('Training epoch: %d samples (%d per mini-batch)', total_samples, batch_size)
+
+    # Switch to train mode
+    model.train()
+    acc_stats = []
+    end = time.time()
+    for train_step, (inputs, target) in enumerate(train_loader):
+        # Measure data loading time
+        data_time.add(time.time() - end)
+        inputs, target = inputs.to(args.device), target.to(args.device)
+
+        # Execute the forward phase, compute the output and measure loss
+        if compression_scheduler:
+            compression_scheduler.on_minibatch_begin(epoch, train_step, steps_per_epoch, optimizer)
+
+        if not hasattr(args, 'kd_policy') or args.kd_policy is None:
+            output = model(inputs)
+        else:
+            output = args.kd_policy.forward(inputs)
+
+        if not args.earlyexit_lossweights:
+            loss = criterion(output, target)
+            # Measure accuracy
+            classerr.add(output.data, target)
+            acc_stats.append([classerr.value(1), classerr.value(5)])
+        else:
+            # Measure accuracy and record loss
+            loss = earlyexit_loss(output, target, criterion, args)
+        # Record loss
+        losses[OBJECTIVE_LOSS_KEY].add(loss.item())
+
+        if compression_scheduler:
+            # Before running the backward phase, we allow the scheduler to modify the loss
+            # (e.g. add regularization loss)
+            agg_loss = compression_scheduler.before_backward_pass(epoch, train_step, steps_per_epoch, loss,
+                                                                  optimizer=optimizer, return_loss_components=True)
+            loss = agg_loss.overall_loss
+            losses[OVERALL_LOSS_KEY].add(loss.item())
+
+            for lc in agg_loss.loss_components:
+                if lc.name not in losses:
+                    losses[lc.name] = tnt.AverageValueMeter()
+                losses[lc.name].add(lc.value.item())
+        else:
+            losses[OVERALL_LOSS_KEY].add(loss.item())
+
+        # Compute the gradient and do SGD step
+        optimizer.zero_grad()
+        loss.backward()
+        if compression_scheduler:
+            compression_scheduler.before_parameter_optimization(epoch, train_step, steps_per_epoch, optimizer)
+        optimizer.step()
+        if compression_scheduler:
+            compression_scheduler.on_minibatch_end(epoch, train_step, steps_per_epoch, optimizer)
+
+        # measure elapsed time
+        batch_time.add(time.time() - end)
+        steps_completed = (train_step+1)
+
+        if steps_completed % args.print_freq == 0:
+            # Log some statistics
+            errs = OrderedDict()
+            if not args.earlyexit_lossweights:
+                errs['Top1'] = classerr.value(1)
+                errs['Top5'] = classerr.value(5)
+            else:
+                # for Early Exit case, the Top1 and Top5 stats are computed for each exit.
+                for exitnum in range(args.num_exits):
+                    errs['Top1_exit' + str(exitnum)] = args.exiterrors[exitnum].value(1)
+                    errs['Top5_exit' + str(exitnum)] = args.exiterrors[exitnum].value(5)
+
+            stats_dict = OrderedDict()
+            for loss_name, meter in losses.items():
+                stats_dict[loss_name] = meter.mean
+            stats_dict.update(errs)
+            stats_dict['LR'] = optimizer.param_groups[0]['lr']
+            stats_dict['Time'] = batch_time.mean
+            stats = ('Performance/Training/', stats_dict)
+
+            params = model.named_parameters() if args.log_params_histograms else None
+            distiller.log_training_progress(stats,
+                                            params,
+                                            epoch, steps_completed,
+                                            steps_per_epoch, args.print_freq,
+                                            loggers)
+        end = time.time()
+    return acc_stat
+
+train = train_one_epoch
+
+
+def validate(val_loader, model, criterion, loggers=None, args=None, epoch=-1):
+    """Model validation"""
+    if epoch > -1:
+        msglogger.info('--- validate (epoch=%d)-----------', epoch)
+    else:
+        msglogger.info('--- validate ---------------------')
+    return _validate(val_loader, model, criterion, loggers, args, epoch)
+
+
+def test(test_loader, model, criterion, loggers=None, activations_collectors=None, args=None):
+    """Model Test"""
+    msglogger.info('--- test ---------------------')
+
+    top1, top5, lossses = _validate(test_loader, model, criterion, loggers, args)
+
+    if activations_collectors is None:
+        activations_collectors = create_activation_stats_collectors(model, None)
+    with collectors_context(activations_collectors["test"]) as collectors:
+        distiller.log_activation_statsitics(-1, "test", loggers, collector=collectors['sparsity'])
+        save_collectors_data(collectors, msglogger.logdir)
+
+    return top1, top5, lossses
+
+
+def _validate(data_loader, model, criterion, loggers=None, args=None, epoch=-1):
+    """Execute the validation/test loop.
+
+    args is required whenever earlyexit is used in the model.
+    """
+    if args is None:
+        args = parser.get_parser().parse_args(['stub'])  # generate stub args object
+        args.device = next(model.parameters()).device  # assuming the whole model resides in the same device
+
+    losses = {'objective_loss': tnt.AverageValueMeter()}
+    classerr = tnt.ClassErrorMeter(accuracy=True, topk=(1, 5))
+
+    if args.earlyexit_thresholds:
+        # for Early Exit, we have a list of errors and losses for each of the exits.
+        args.exiterrors = []
+        args.losses_exits = []
+        for exitnum in range(args.num_exits):
+            args.exiterrors.append(tnt.ClassErrorMeter(accuracy=True, topk=(1, 5)))
+            args.losses_exits.append(tnt.AverageValueMeter())
+        args.exit_taken = [0] * args.num_exits
+
+    batch_time = tnt.AverageValueMeter()
+    total_samples = len(data_loader.sampler)
+    batch_size = data_loader.batch_size
+    if args.display_confusion:
+        confusion = tnt.ConfusionMeter(args.num_classes)
+    total_steps = total_samples / batch_size
+    msglogger.info('%d samples (%d per mini-batch)', total_samples, batch_size)
+
+    # Switch to evaluation mode
+    model.eval()
+
+    end = time.time()
+    for validation_step, (inputs, target) in enumerate(data_loader):
+        with torch.no_grad():
+            inputs, target = inputs.to(args.device), target.to(args.device)
+            # compute output from model
+            output = model(inputs)
+
+            if not args.earlyexit_thresholds:
+                # compute loss
+                loss = criterion(output, target)
+                # measure accuracy and record loss
+                losses['objective_loss'].add(loss.item())
+                classerr.add(output.data, target)
+                if args.display_confusion:
+                    confusion.add(output.data, target)
+            else:
+                earlyexit_validate_loss(output, target, criterion, args)
+
+            # measure elapsed time
+            batch_time.add(time.time() - end)
+            end = time.time()
+
+            steps_completed = (validation_step+1)
+            if (loggers is not None) and (steps_completed % args.print_freq == 0):
+                if not args.earlyexit_thresholds:
+                    stats = ('',
+                        OrderedDict([('Loss', losses['objective_loss'].mean),
+                                     ('Top1', classerr.value(1)),
+                                     ('Top5', classerr.value(5))]))
+                else:
+                    stats_dict = OrderedDict()
+                    stats_dict['Test'] = validation_step
+                    for exitnum in range(args.num_exits):
+                        la_string = 'LossAvg' + str(exitnum)
+                        stats_dict[la_string] = args.losses_exits[exitnum].mean
+                        # Because of the nature of ClassErrorMeter, if an exit is never taken during the batch,
+                        # then accessing the value(k) will cause a divide by zero. So we'll build the OrderedDict
+                        # accordingly and we will not print for an exit error when that exit is never taken.
+                        if args.exit_taken[exitnum]:
+                            t1 = 'Top1_exit' + str(exitnum)
+                            t5 = 'Top5_exit' + str(exitnum)
+                            stats_dict[t1] = args.exiterrors[exitnum].value(1)
+                            stats_dict[t5] = args.exiterrors[exitnum].value(5)
+                    stats = ('Performance/Validation/', stats_dict)
+
+                distiller.log_training_progress(stats, None, epoch, steps_completed,
+                                                total_steps, args.print_freq, loggers)
+
+    if not args.earlyexit_thresholds:
+        msglogger.info('==> Top1: %.3f    Top5: %.3f    Loss: %.3f\n',
+                       classerr.value()[0], classerr.value()[1], losses['objective_loss'].mean)
+
+        if args.display_confusion:
+            msglogger.info('==> Confusion:\n%s\n', str(confusion.value()))
+        return classerr.value(1), classerr.value(5), losses['objective_loss'].mean
+    else:
+        total_top1, total_top5, losses_exits_stats = earlyexit_validate_stats(args)
+        return total_top1, total_top5, losses_exits_stats[args.num_exits-1]
+
+
+def update_training_scores_history(perf_scores_history, model, top1, top5, epoch, num_best_scores):
+    """ Update the list of top training scores achieved so far, and log the best scores so far"""
+
+    model_sparsity, _, params_nnz_cnt = distiller.model_params_stats(model)
+    perf_scores_history.append(distiller.MutableNamedTuple({'params_nnz_cnt': -params_nnz_cnt,
+                                                            'sparsity': model_sparsity,
+                                                            'top1': top1, 'top5': top5, 'epoch': epoch}))
+    # Keep perf_scores_history sorted from best to worst
+    # Sort by sparsity as main sort key, then sort by top1, top5 and epoch
+    perf_scores_history.sort(key=operator.attrgetter('params_nnz_cnt', 'top1', 'top5', 'epoch'), reverse=True)
+    for score in perf_scores_history[:num_best_scores]:
+        msglogger.info('==> Best [Top1: %.3f   Top5: %.3f   Sparsity:%.2f   Params: %d on epoch: %d]',
+                       score.top1, score.top5, score.sparsity, -score.params_nnz_cnt, score.epoch)
+
+
+def earlyexit_loss(output, target, criterion, args):
+    loss = 0
+    sum_lossweights = 0
+    for exitnum in range(args.num_exits-1):
+        loss += (args.earlyexit_lossweights[exitnum] * criterion(output[exitnum], target))
+        sum_lossweights += args.earlyexit_lossweights[exitnum]
+        args.exiterrors[exitnum].add(output[exitnum].data, target)
+    # handle final exit
+    loss += (1.0 - sum_lossweights) * criterion(output[args.num_exits-1], target)
+    args.exiterrors[args.num_exits-1].add(output[args.num_exits-1].data, target)
+    return loss
+
+
+def earlyexit_validate_loss(output, target, criterion, args):
+    # We need to go through each sample in the batch itself - in other words, we are
+    # not doing batch processing for exit criteria - we do this as though it were batchsize of 1
+    # but with a grouping of samples equal to the batch size.
+    # Note that final group might not be a full batch - so determine actual size.
+    this_batch_size = target.size()[0]
+    earlyexit_validate_criterion = nn.CrossEntropyLoss(reduce=False).to(args.device)
+
+    for exitnum in range(args.num_exits):
+        # calculate losses at each sample separately in the minibatch.
+        args.loss_exits[exitnum] = earlyexit_validate_criterion(output[exitnum], target)
+        # for batch_size > 1, we need to reduce this down to an average over the batch
+        args.losses_exits[exitnum].add(torch.mean(args.loss_exits[exitnum]).cpu())
+
+    for batch_index in range(this_batch_size):
+        earlyexit_taken = False
+        # take the exit using CrossEntropyLoss as confidence measure (lower is more confident)
+        for exitnum in range(args.num_exits - 1):
+            if args.loss_exits[exitnum][batch_index] < args.earlyexit_thresholds[exitnum]:
+                # take the results from early exit since lower than threshold
+                args.exiterrors[exitnum].add(torch.tensor(np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)),
+                                             torch.full([1], target[batch_index], dtype=torch.long))
+                args.exit_taken[exitnum] += 1
+                earlyexit_taken = True
+                break                    # since exit was taken, do not affect the stats of subsequent exits
+        # this sample does not exit early and therefore continues until final exit
+        if not earlyexit_taken:
+            exitnum = args.num_exits - 1
+            args.exiterrors[exitnum].add(torch.tensor(np.array(output[exitnum].data[batch_index].cpu(), ndmin=2)),
+                                         torch.full([1], target[batch_index], dtype=torch.long))
+            args.exit_taken[exitnum] += 1
+
+
+def earlyexit_validate_stats(args):
+    # Print some interesting summary stats for number of data points that could exit early
+    top1k_stats = [0] * args.num_exits
+    top5k_stats = [0] * args.num_exits
+    losses_exits_stats = [0] * args.num_exits
+    sum_exit_stats = 0
+    for exitnum in range(args.num_exits):
+        if args.exit_taken[exitnum]:
+            sum_exit_stats += args.exit_taken[exitnum]
+            msglogger.info("Exit %d: %d", exitnum, args.exit_taken[exitnum])
+            top1k_stats[exitnum] += args.exiterrors[exitnum].value(1)
+            top5k_stats[exitnum] += args.exiterrors[exitnum].value(5)
+            losses_exits_stats[exitnum] += args.losses_exits[exitnum].mean
+    for exitnum in range(args.num_exits):
+        if args.exit_taken[exitnum]:
+            msglogger.info("Percent Early Exit %d: %.3f", exitnum,
+                           (args.exit_taken[exitnum]*100.0) / sum_exit_stats)
+    total_top1 = 0
+    total_top5 = 0
+    for exitnum in range(args.num_exits):
+        total_top1 += (top1k_stats[exitnum] * (args.exit_taken[exitnum] / sum_exit_stats))
+        total_top5 += (top5k_stats[exitnum] * (args.exit_taken[exitnum] / sum_exit_stats))
+        msglogger.info("Accuracy Stats for exit %d: top1 = %.3f, top5 = %.3f", exitnum, top1k_stats[exitnum], top5k_stats[exitnum])
+    msglogger.info("Totals for entire network with early exits: top1 = %.3f, top5 = %.3f", total_top1, total_top5)
+    return total_top1, total_top5, losses_exits_stats
+
+
+def sensitivity_analysis(model, criterion, data_loader, loggers, args, sparsities):
+    # This sample application can be invoked to execute Sensitivity Analysis on your
+    # model.  The ouptut is saved to CSV and PNG.
+    msglogger.info("Running sensitivity tests")
+    if not isinstance(loggers, list):
+        loggers = [loggers]
+    test_fnc = partial(test, test_loader=data_loader, criterion=criterion,
+                       loggers=loggers, args=args,
+                       activations_collectors=create_activation_stats_collectors(model))
+    which_params = [param_name for param_name, _ in model.named_parameters()]
+    sensitivity = distiller.perform_sensitivity_analysis(model,
+                                                         net_params=which_params,
+                                                         sparsities=sparsities,
+                                                         test_func=test_fnc,
+                                                         group=args.sensitivity)
+    distiller.sensitivities_to_png(sensitivity, os.path.join(msglogger.logdir, 'sensitivity.png'))
+    distiller.sensitivities_to_csv(sensitivity, os.path.join(msglogger.logdir, 'sensitivity.csv'))
+
+
+def automated_deep_compression(model, criterion, optimizer, loggers, args):
+    train_loader, val_loader, test_loader, _ = load_data(args)
+
+    args.display_confusion = True
+    validate_fn = partial(test, test_loader=test_loader, criterion=criterion,
+                          loggers=loggers, args=args, activations_collectors=None)
+    train_fn = partial(train, train_loader=train_loader, criterion=criterion,
+                       loggers=loggers, args=args)
+
+    save_checkpoint_fn = partial(apputils.save_checkpoint, arch=args.arch, dir=msglogger.logdir)
+    optimizer_data = {'lr': args.lr, 'momentum': args.momentum, 'weight_decay': args.weight_decay}
+    adc.do_adc(model, args, optimizer_data, validate_fn, save_checkpoint_fn, train_fn)
+
+
+def greedy(model, criterion, optimizer, loggers, args):
+    train_loader, val_loader, test_loader, _ = load_data(args)
+
+    test_fn = partial(test, test_loader=test_loader, criterion=criterion,
+                      loggers=loggers, args=args, activations_collectors=None)
+    train_fn = partial(train, train_loader=train_loader, criterion=criterion, args=args)
+    assert args.greedy_target_density is not None
+    distiller.pruning.greedy_filter_pruning.greedy_pruner(model, args,
+                                                          args.greedy_target_density,
+                                                          args.greedy_pruning_step,
+                                                          test_fn, train_fn)
+
+
+def acts_quant_stats_collection(test_loader, model, criterion, loggers, args, save_to_file=False):
+    msglogger.info('Collecting quantization calibration stats based on {:.1%} of test dataset'
+                   .format(args.qe_calibration))
+    test_fn = partial(test, test_loader=test_loader, criterion=criterion,
+                      loggers=loggers, args=args, activations_collectors=None)
+    with distiller.get_nonparallel_clone_model(model) as cmodel:
+        return collect_quant_stats(cmodel, test_fn, classes=None,
+                                   inplace_runtime_check=True, disable_inplace_attrs=True,
+                                   save_dir=msglogger.logdir if save_to_file else None)
+
+
+def acts_histogram_collection(model, criterion, loggers, args):
+    msglogger.info('Collecting activation histograms based on {:.1%} of test dataset'
+                   .format(args.activation_histograms))
+    model = distiller.utils.make_non_parallel_copy(model)
+    args.effective_test_size = args.activation_histograms
+    train_loader, val_loader, test_loader, _ = load_data(args, fixed_subset=True)
+    test_fn = partial(test, test_loader=test_loader, criterion=criterion,
+                      loggers=loggers, args=args, activations_collectors=None)
+    collect_histograms(model, test_fn, save_dir=msglogger.logdir,
+                       classes=None, nbins=2048, save_hist_imgs=True)
+
+
+def load_data(args, fixed_subset=False):
+    return apputils.load_data(args.dataset, os.path.expanduser(args.data), args.batch_size,
+                              args.workers, args.validation_split, args.deterministic,
+                              args.effective_train_size, args.effective_valid_size, args.effective_test_size,
+                              fixed_subset)
+
+
+class missingdict(dict):
+    """This is a little trick to prevent KeyError"""
+    def __missing__(self, key):
+        return None  # note, does *not* set self[key] - we don't want defaultdict's behavior
+
+
+def create_activation_stats_collectors(model, *phases):
+    """Create objects that collect activation statistics.
+
+    This is a utility function that creates two collectors:
+    1. Fine-grade sparsity levels of the activations
+    2. L1-magnitude of each of the activation channels
+
+    Args:
+        model - the model on which we want to collect statistics
+        phases - the statistics collection phases: train, valid, and/or test
+
+    WARNING! Enabling activation statsitics collection will significantly slow down training!
+    """
+    genCollectors = lambda: missingdict({
+        "sparsity":      SummaryActivationStatsCollector(model, "sparsity",
+                                                         lambda t: 100 * distiller.utils.sparsity(t)),
+        "l1_channels":   SummaryActivationStatsCollector(model, "l1_channels",
+                                                         distiller.utils.activation_channels_l1),
+        "apoz_channels": SummaryActivationStatsCollector(model, "apoz_channels",
+                                                         distiller.utils.activation_channels_apoz),
+        "mean_channels": SummaryActivationStatsCollector(model, "mean_channels",
+                                                         distiller.utils.activation_channels_means),
+        "records":       RecordsActivationStatsCollector(model, classes=[torch.nn.Conv2d])
+    })
+
+    return {k: (genCollectors() if k in phases else missingdict())
+            for k in ('train', 'valid', 'test')}
+
+
+def save_collectors_data(collectors, directory):
+    """Utility function that saves all activation statistics to disk.
+
+    File type and format of contents are collector-specific.
+    """
+    for name, collector in collectors.items():
+        msglogger.info('Saving data for collector {}...'.format(name))
+        file_path = collector.save(os.path.join(directory, name))
+        msglogger.info("Saved to {}".format(file_path))
+
+
+def quantize_and_test_model(test_loader, model, criterion, loggers=None, activations_collectors=None, args=None,
+                            scheduler=None, save_flag=False):
+    if args is None:
+        raise NotImplementedError('args cannot be set to None')
+
+    if not args.qe_stats_file:
+        args_copy = copy.deepcopy(args)
+        args_copy.qe_calibration = args.qe_calibration if args.qe_calibration is not None else 0.05
+        args_copy.effective_test_size = args_copy.qe_calibration
+        args.qe_stats_file = acts_quant_stats_collection(load_data(args_copy)[2], model, criterion, loggers, args_copy)
+
+    with distiller.get_nonparallel_clone_model(model) as qe_model:
+        qe_model.cpu()
+        quantizer = quantization.PostTrainLinearQuantizer.from_args(qe_model, args)
+        quantizer.prepare_model(distiller.get_dummy_input(input_shape=model.input_shape))
+        qe_model.to(args.device)
+
+        test_res = test(test_loader, qe_model, criterion, loggers, activations_collectors, args=args)
+
+        if save_flag:
+            checkpoint_name = 'quantized'
+            apputils.save_checkpoint(0, args.arch, qe_model, scheduler=scheduler,
+                                     name='_'.join([args.name, checkpoint_name]) if args.name else checkpoint_name,
+                                     dir=msglogger.logdir, extras={'quantized_top1': test_res[0]})
+
+    return test_res


### PR DESCRIPTION
Motivation: I wanted to facilitate the access to the compress_classifier's internal functions, which I use frequently, and potentially, provide different API to same train/valid/test func call.
e.g. "compress_classifier_v2.py"

------------------------------
Move the majority of functionalities from compress_classifier.py to separate file imageclass.py, under distiller.
The function will henceforth will be imported automatically upon calling `import distiller`.

Also, some smaller modifications:
* evaluate_model() calls either test, or quantize and then test, which will now also calibrate.
  Calibration and testing of the quantized models will run on cloned model.
* Rename train() to train_one_epoch()
* Allow calling test and validate/test with less arguments.
  The following arguments are now optional: loggers, collectors, and args.
* acts_quant_stats_collection will return the results stats, and saving
  to file is not optional, false by default.
* qe_calibration argument is set to None, by default.
* Added get_nonparallel_clone_model to handle cloning and discarding of models.