### PR TITLE
LpRankedStructureParameterPruner: work with 3D filters (ie Conv1d)

### DIFF
--- a/distiller/pruning/ranked_structures_pruner.py
+++ b/distiller/pruning/ranked_structures_pruner.py
@@ -220,7 +220,7 @@ class LpRankedStructureParameterPruner(_RankedStructureParameterPruner):
     def rank_and_prune_filters(fraction_to_prune, param, param_name, zeros_mask_dict, 
                                model=None, binary_map=None, magnitude_fn=l1_magnitude, 
                                noise=0.0, group_size=1, rounding_fn=math.floor):
-        assert param.dim() == 4, "This pruning is only supported for 4D weights"
+        assert param.dim() == 4 or param.dim() == 3, "This pruning is only supported for 3D and 4D weights"
 
         threshold = None
         threshold_type = 'L1' if magnitude_fn == l1_magnitude else 'L2'

--- a/distiller/thresholding.py
+++ b/distiller/thresholding.py
@@ -85,7 +85,7 @@ def group_threshold_binary_map(param, group_type, threshold, threshold_criteria)
         return binary_map
 
     elif group_type == '3D' or group_type == 'Filters':
-        assert param.dim() == 4, "This thresholding is only supported for 4D weights"
+        assert param.dim() == 4 or param.dim() == 3, "This pruning is only supported for 3D and 4D weights"
         view_filters = param.view(param.size(0), -1)
         thresholds = torch.Tensor([threshold] * param.size(0)).to(param.device)
         binary_map = threshold_policy(view_filters, thresholds, threshold_criteria)
@@ -153,7 +153,7 @@ def group_threshold_mask(param, group_type, threshold, threshold_criteria, binar
     elif group_type == '3D' or group_type == 'Filters':
         if binary_map is None:
             binary_map = group_threshold_binary_map(param, group_type, threshold, threshold_criteria)
-        a = binary_map.expand(param.size(1) * param.size(2) * param.size(3), param.size(0)).t()
+        a = binary_map.expand(torch.tensor(param.shape)[1:].prod(), param.size(0)).t()
         return a.view(*param.shape), binary_map
 
     elif group_type == '4D':

--- a/distiller/thresholding.py
+++ b/distiller/thresholding.py
@@ -19,6 +19,7 @@
 The code below supports fine-grained tensor thresholding and group-wise thresholding.
 """
 import torch
+import numpy as np
 
 
 def threshold_mask(weights, threshold):
@@ -153,7 +154,7 @@ def group_threshold_mask(param, group_type, threshold, threshold_criteria, binar
     elif group_type == '3D' or group_type == 'Filters':
         if binary_map is None:
             binary_map = group_threshold_binary_map(param, group_type, threshold, threshold_criteria)
-        a = binary_map.expand(torch.tensor(param.shape)[1:].prod(), param.size(0)).t()
+        a = binary_map.expand(np.prod(param.shape[1:]), param.size(0)).t()
         return a.view(*param.shape), binary_map
 
     elif group_type == '4D':


### PR DESCRIPTION
I made these changes to work with the L1RankedStructureParameterPruner_AGP class. The network gets pruned and there are no errors.

The sparsity summary shows 2D/3D pruning only on the 4D filter (screenshot included), I don't know if that's normal.
![Screenshot from 2019-08-08 11-16-53](https://user-images.githubusercontent.com/6899116/62691024-19471080-b9ce-11e9-8d6d-914a62ac4ece.png)
