### PR TITLE
support quantize weights/bias only

### DIFF
--- a/distiller/quantization/quantizer.py
+++ b/distiller/quantization/quantizer.py
@@ -113,7 +113,7 @@ class Quantizer(object):
             raise ValueError('optimizer cannot be None when train_with_fp_copy is True')
 
         self.adjacency_map = None  # To be populated during prepare_model()
-
+        bits_activations = None if type(bits_activations) == str and bits_activations.lower() == 'none' else bits_activations
         self.default_qbits = QBits(acts=bits_activations, wts=bits_weights, bias=bits_bias)
         self.overrides = overrides
 
@@ -132,7 +132,8 @@ class Quantizer(object):
                 raise ValueError("Using 'acts' / 'wts' / 'bias' to specify bit-width overrides is deprecated.\n"
                                  "Please use the full parameter names: "
                                  "'bits_activations' / 'bits_weights' / 'bits_bias'")
-            qbits = QBits(acts=v.pop('bits_activations', self.default_qbits.acts),
+            acts = v.pop('bits_activations', self.default_qbits.acts)
+            qbits = QBits(acts=None if type(acts) == str and acts.lower() == 'none' else acts,
                           wts=v.pop('bits_weights', self.default_qbits.wts),
                           bias=v.pop('bits_bias', self.default_qbits.bias))
             v['bits'] = qbits


### PR DESCRIPTION
I add support quantizing weights only in the post training quantization when users set `qe-bits-acts=None`. It directly uses quantize-dequantize operations on weights and keep activations fp32 and no warp on layers. In this implementation, i follow @guyjacob 's advice and put them in replace_param_layer of base Quantizer class. When users use config file and set the bits of activation to None, it would be string 'None'  so i give a special handle to this case in quantizer.py.