### PR TITLE
Add new flags to activation collector class

### DIFF
--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -55,7 +55,7 @@ class ActivationStatsCollector(object):
     We can remove some of the slowness, by choosing to log only specific layers or use it only
     during validation or test. This can be achieved using the `classes` argument.
     """
-    def __init__(self, model, stat_name, classes):
+    def __init__(self, model, stat_name, classes, inclusion_flag=True):
         """
         Args:
             model - the model we are monitoring.
@@ -65,11 +65,14 @@ class ActivationStatsCollector(object):
                     print(module.sparsity)
             classes - a list of class types for which we collect activation statistics.
                 Passing an empty list or None will collect statistics for all class types.
+            inclusion_flag - When set to False, exclude all class types listed in classes, collect
+                on all other types.
         """
         super(ActivationStatsCollector, self).__init__()
         self.model = model
         self.stat_name = stat_name
         self.classes = classes
+        self.inclusion_flag = inclusion_flag
         self.fwd_hook_handles = []
 
         # The layer names are mangled, because torch.Modules don't have names and we need to invent
@@ -99,7 +102,8 @@ class ActivationStatsCollector(object):
         if distiller.has_children(module) or isinstance(module, torch.nn.Identity):
             return
         register_all_class_types = not self.classes
-        if register_all_class_types or isinstance(module, tuple(self.classes)):
+        if register_all_class_types or (operator.xor(
+                not isinstance(module, tuple(self.classes)), self.inclusion_flag)):
             self.fwd_hook_handles.append(module.register_forward_hook(self._activation_stats_cb))
             self._start_counter(module)
 
@@ -147,10 +151,13 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
     light-weight and quicker than collecting a record per activation.
     The statistic function is configured in the constructor.
     """
-    def __init__(self, model, stat_name, summary_fn, classes=[torch.nn.ReLU,
-                                                              torch.nn.ReLU6,
-                                                              torch.nn.LeakyReLU]):
-        super(SummaryActivationStatsCollector, self).__init__(model, stat_name, classes)
+    def __init__(self, model, stat_name, summary_fn,
+                 classes=[torch.nn.ReLU, torch.nn.ReLU6, torch.nn.LeakyReLU],
+                 inclusion_flag=True, inputs_flag=False, outputs_flag=True):
+        super().__init__(model, stat_name, classes, inclusion_flag)
+        self.inputs_flag = inputs_flag
+        self.outputs_flag = outputs_flag
+        assert self.inputs_flag ^ self.outputs_flag, 'Both outputs and inputs were selected'
         self.summary_fn = summary_fn
 
     def _activation_stats_cb(self, module, input, output):
@@ -158,8 +165,20 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
 
         This is a callback from the forward() of 'module'.
         """
+        if self.outputs_flag:
+            t = output
+        elif self.inputs_flag:
+            if len(input) == 0:
+                return
+            elif len(input) > 1:
+                raise NotImplementedError('only single input layers are currently supported')
+            t = input[0]
+
         try:
-            getattr(module, self.stat_name).add(self.summary_fn(output.data))
+            # This implementation of updating the average is not perfect because smaller
+            # batches (usually in the "tail" of the epoch) will have equivalent weight
+            # to any other batch in the epoch
+            getattr(module, self.stat_name)['mean'].add(self.summary_fn(t.data))
         except RuntimeError as e:
             if "The expanded size of the tensor" in e.args[0]:
                 raise ValueError("ActivationStatsCollector: a module ({} - {}) was encountered twice during model.apply().\n"
@@ -173,27 +192,36 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
                 msglogger.info("Exception in _activation_stats_cb: {} {}".format(module.distiller_name, type(module)))
                 raise
 
+        if getattr(module, self.stat_name)['size'] == 0:
+            # exclude the batch size from the tensor's shape, and multiply to get the size
+            size = reduce(operator.mul, list(t.data.size())[1:], 1)
+            getattr(module, self.stat_name)['size'] = size
+
     def _start_counter(self, module):
         if not hasattr(module, self.stat_name):
-            setattr(module, self.stat_name, AverageValueMeter())
+            setattr(module, self.stat_name, dict())
             # Assign a name to this summary
             if hasattr(module, 'distiller_name'):
-                getattr(module, self.stat_name).name = '_'.join((self.stat_name, module.distiller_name))
+                getattr(module, self.stat_name)['name'] = '_'.join((self.stat_name, module.distiller_name))
             else:
-                getattr(module, self.stat_name).name = '_'.join((self.stat_name,
+                getattr(module, self.stat_name)['name'] = '_'.join((self.stat_name,
                                                                  module.__class__.__name__,
                                                                  str(id(module))))
+            getattr(module, self.stat_name)['mean'] = AverageValueMeter()
+            getattr(module, self.stat_name)['size'] = 0
 
     def _reset_counter(self, module):
         if hasattr(module, self.stat_name):
-            getattr(module, self.stat_name).reset()
+            getattr(module, self.stat_name)['mean'].reset()
+            getattr(module, self.stat_name)['size'] = 0
 
     def _collect_activations_stats(self, module, activation_stats, name=''):
         if hasattr(module, self.stat_name):
-            mean = getattr(module, self.stat_name).mean
+            mean = getattr(module, self.stat_name)['mean'].value()[0]
             if isinstance(mean, torch.Tensor):
                 mean = mean.tolist()
-            activation_stats[getattr(module, self.stat_name).name] = mean
+            activation_stats[module.distiller_name] = {
+                'mean': mean, 'size': getattr(module, self.stat_name)['size']}
 
     def save(self, fname):
         """Save the records to an Excel workbook, with one worksheet per layer.
@@ -208,11 +236,12 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
         with xlsxwriter.Workbook(fname) as workbook:
             worksheet = workbook.add_worksheet(self.stat_name)
             col_names = []
-            for col, (module_name, module_summary_data) in enumerate(records_dict.items()):
-                if not isinstance(module_summary_data, list):
-                    module_summary_data = [module_summary_data]
-                worksheet.write_column(1, col, module_summary_data)
-                col_names.append(module_name)
+            for col_index, (col_name, col_data) in enumerate(records_dict.items()):
+                for i, (k, v) in enumerate(col_data.items()):
+                    if not isinstance(v, list):
+                        v = [v]
+                    worksheet.write_column(i+1, col_index, v)
+                col_names.append(col_name)
             worksheet.write_row(0, 0, col_names)
         return fname
 
@@ -289,6 +318,8 @@ class RecordsActivationStatsCollector(ActivationStatsCollector):
                 for col, (col_name, col_data) in enumerate(module_act_records.items()):
                     if col_name == 'shape':
                         continue
+                    if not isinstance(col_data, list):
+                        col_data = [col_data]
                     worksheet.write_column(1, col, col_data)
                     col_names.append(col_name)
                 worksheet.write_row(0, 0, col_names)


### PR DESCRIPTION
This patch extends the options on the activation collector class:
1. Allow the option to treat classes argument as black list instead of white list.
2. Allow to collect summary on inputs, not just outputs. Currently mutually exclusive.
3. Print matrix size (useful for weighted averages) [This change reflects on the Excel files]

This is not necessarily final commit, many improvements can be done.
If that's of interest, this patch can be extended to more collector classes.