### PR TITLE
Change requirements on Tensorflow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torchvision==0.3.0
 scipy>=1.3.0
 gitpython==2.1.11
 torchnet==0.0.4
-tensorflow>=1.14
+tensorflow~=1.14
 pydot==1.4.1
 tabulate==0.8.3
 pandas>=0.22.0


### PR DESCRIPTION
Hot-fix for issue that arises with FileWriter class on TF v2.
Allows only Tensorflow v1.X

For more details on the change: https://www.tensorflow.org/tensorboard/migrate