### PR TITLE
Correct handling of different batch-sizes in collectors

### DIFF
--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -479,10 +479,9 @@ class QuantCalibrationStatsCollector(ActivationStatsCollector):
                 prev_mean (float): the previous running mean
                 total_values_so_far (int): the number of the values so far
             """
-            curr_mean = values.mean().item()
             curr_numel = values.numel()
             prev_numel = total_values_so_far
-            return (prev_numel * prev_mean + curr_numel * curr_mean) / (prev_numel + curr_numel)
+            return (prev_numel * prev_mean + values.sum().item()) / (prev_numel + curr_numel)
 
         def update_std(values, prev_std, mean, total_values_so_far):
             """

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -154,8 +154,7 @@ class RunningStatsMeter(AverageValueMeter):
     std collection correctly by taking into account the batch size.
     """
     def add(self, value, n=1):
-        self.val = value
-        self.sum += value
+        self.sum += value*n
         if n <= 0:
             raise ValueError("Cannot use a non-positive weight for the running stat.")
         elif self.n == 0:
@@ -164,10 +163,12 @@ class RunningStatsMeter(AverageValueMeter):
             self.mean_old = self.mean
             self.m_s = 0.0
         else:
-            self.mean = self.mean_old + (value - n * self.mean_old) / float(self.n+n)
+            self.mean = self.mean_old + n * (value - self.mean_old) / float(self.n+n)
             self.m_s += n*(value - self.mean_old) * (value - self.mean)
             self.mean_old = self.mean
             self.std = np.sqrt(self.m_s / (self.n + n - 1.0))
+        self.var = self.std**2
+
         self.n += n
 
 

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -148,7 +148,7 @@ class ActivationStatsCollector(object):
         raise NotImplementedError
 
 
-class RunningStatsMeter(AverageValueMeter):
+class WeightedAverageValueMeter(AverageValueMeter):
     """
     A correction to torchnet's AverageValueMeter which doesn't implement
     std collection correctly by taking into account the batch size.
@@ -158,7 +158,7 @@ class RunningStatsMeter(AverageValueMeter):
         if n <= 0:
             raise ValueError("Cannot use a non-positive weight for the running stat.")
         elif self.n == 0:
-            self.mean = 0.0 + self.sum  # This is to force a copy in torch/numpy
+            self.mean = 0.0 + value  # This is to force a copy in torch/numpy
             self.std = np.inf
             self.mean_old = self.mean
             self.m_s = 0.0
@@ -207,7 +207,7 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
 
     def _start_counter(self, module):
         if not hasattr(module, self.stat_name):
-            setattr(module, self.stat_name, RunningStatsMeter())
+            setattr(module, self.stat_name, WeightedAverageValueMeter())
             # Assign a name to this summary
             if hasattr(module, 'distiller_name'):
                 getattr(module, self.stat_name).name = '_'.join((self.stat_name, module.distiller_name))

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -156,11 +156,9 @@ class RunningStatsMeter(AverageValueMeter):
     def add(self, value, n=1):
         self.val = value
         self.sum += value
-        self.var += value * value
-
         if n <= 0:
             raise ValueError("Cannot use a non-positive weight for the running stat.")
-        elif self.n == 1:
+        elif self.n == 0:
             self.mean = 0.0 + self.sum  # This is to force a copy in torch/numpy
             self.std = np.inf
             self.mean_old = self.mean

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -460,15 +460,6 @@ class QuantCalibrationStatsCollector(ActivationStatsCollector):
             m = current_sample_numel
             return (t*old_mean + m*new_val) / (t+m)
 
-        # def update_std(values, old_std, old_mean, new_mean, total_values_so_far):
-        #     # See here:
-        #     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_Online_algorithm
-        #     numel = values.numel() if isinstance(values, torch.Tensor) else values.size
-        #     M = (old_std ** 2) * (total_values_so_far - 1)
-        #     mean_diffs = (values - old_mean) * (values - new_mean)
-        #     M += mean_diffs.sum()
-        #     return sqrt((M / (total_values_so_far + numel - 1)).item())
-
         def update_std(values, old_std, mean, total_values_so_far):
             """
             Updates std of the module.


### PR DESCRIPTION
Pointed out by @Pavelrst :)
Standard deviation calculation was calculated with an average over batches, where the last batch might be very small and hence less elements.  
Corrected by calculating std in the second pass by definition (after `mean` was calculated) .
