### PR TITLE
Update internal ResNet implementation according to latest TorchVision

### DIFF
--- a/distiller/models/__init__.py
+++ b/distiller/models/__init__.py
@@ -36,7 +36,8 @@ SUPPORTED_DATASETS = ('imagenet', 'cifar10', 'mnist')
 
 # ResNet special treatment: we have our own version of ResNet, so we need to over-ride
 # TorchVision's version.
-RESNET_SYMS = ('ResNet', 'resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152')
+RESNET_SYMS = ('ResNet', 'resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152',
+               'resnext50_32x4d', 'resnext101_32x8d')
 
 TORCHVISION_MODEL_NAMES = sorted(
                             name for name in torch_models.__dict__


### PR DESCRIPTION
Changed our version to only re-implement BasicBlock and Bottleneck,
and duplicate the model creation functions. Other than that, re-use
everything from the torchvision implementation.