### PR TITLE
IFM sparsity collector

### DIFF
--- a/distiller/apputils/image_classifier.py
+++ b/distiller/apputils/image_classifier.py
@@ -444,7 +444,7 @@ def create_activation_stats_collectors(model, *phases):
 
     genCollectors = lambda: missingdict({
         "sparsity_ifm":      SummaryActivationStatsCollector(model, "sparsity_ifm",
-            lambda t: 100 * distiller.utils.sparsity(t), in_or_out='in', classes=None),
+            lambda t: 100 * distiller.utils.sparsity(t), classes=None, output_flag=False),
         "sparsity_ofm":      SummaryActivationStatsCollector(model, "sparsity_ofm",
             lambda t: 100 * distiller.utils.sparsity(t)),
         "l1_channels":   SummaryActivationStatsCollector(model, "l1_channels",

--- a/distiller/apputils/image_classifier.py
+++ b/distiller/apputils/image_classifier.py
@@ -443,9 +443,6 @@ def create_activation_stats_collectors(model, *phases):
             return None  # note, does *not* set self[key] - we don't want defaultdict's behavior
 
     genCollectors = lambda: missingdict({
-        "sparsity_ifm":      SummaryActivationStatsCollector(model, "sparsity_ifm",
-            lambda t: 100 * distiller.utils.sparsity(t),
-            collector_direction=CollectorDirection.IFM, classes=None),
         "sparsity_ofm":      SummaryActivationStatsCollector(model, "sparsity_ofm",
             lambda t: 100 * distiller.utils.sparsity(t)),
         "l1_channels":   SummaryActivationStatsCollector(model, "l1_channels",

--- a/distiller/apputils/image_classifier.py
+++ b/distiller/apputils/image_classifier.py
@@ -444,8 +444,7 @@ def create_activation_stats_collectors(model, *phases):
 
     genCollectors = lambda: missingdict({
         "sparsity_ifm":      SummaryActivationStatsCollector(model, "sparsity_ifm",
-            lambda t: 100 * distiller.utils.sparsity(t), in_or_out='in',
-            classes=[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Softmax, torch.nn.MaxPool2d, torch.nn.AdaptiveAvgPool2d]),
+            lambda t: 100 * distiller.utils.sparsity(t), in_or_out='in', classes=None),
         "sparsity_ofm":      SummaryActivationStatsCollector(model, "sparsity_ofm",
             lambda t: 100 * distiller.utils.sparsity(t)),
         "l1_channels":   SummaryActivationStatsCollector(model, "l1_channels",

--- a/distiller/apputils/image_classifier.py
+++ b/distiller/apputils/image_classifier.py
@@ -444,7 +444,8 @@ def create_activation_stats_collectors(model, *phases):
 
     genCollectors = lambda: missingdict({
         "sparsity_ifm":      SummaryActivationStatsCollector(model, "sparsity_ifm",
-            lambda t: 100 * distiller.utils.sparsity(t), classes=None, output_flag=False),
+            lambda t: 100 * distiller.utils.sparsity(t),
+            collector_direction=CollectorDirection.IFM, classes=None),
         "sparsity_ofm":      SummaryActivationStatsCollector(model, "sparsity_ofm",
             lambda t: 100 * distiller.utils.sparsity(t)),
         "l1_channels":   SummaryActivationStatsCollector(model, "l1_channels",

--- a/distiller/apputils/image_classifier.py
+++ b/distiller/apputils/image_classifier.py
@@ -443,8 +443,11 @@ def create_activation_stats_collectors(model, *phases):
             return None  # note, does *not* set self[key] - we don't want defaultdict's behavior
 
     genCollectors = lambda: missingdict({
-        "sparsity":      SummaryActivationStatsCollector(model, "sparsity",
-                                                         lambda t: 100 * distiller.utils.sparsity(t)),
+        "sparsity_ifm":      SummaryActivationStatsCollector(model, "sparsity_ifm",
+            lambda t: 100 * distiller.utils.sparsity(t), in_or_out='in',
+            classes=[torch.nn.Conv2d, torch.nn.Linear, torch.nn.Softmax, torch.nn.MaxPool2d, torch.nn.AdaptiveAvgPool2d]),
+        "sparsity_ofm":      SummaryActivationStatsCollector(model, "sparsity_ofm",
+            lambda t: 100 * distiller.utils.sparsity(t)),
         "l1_channels":   SummaryActivationStatsCollector(model, "l1_channels",
                                                          distiller.utils.activation_channels_l1),
         "apoz_channels": SummaryActivationStatsCollector(model, "apoz_channels",

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -212,7 +212,7 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
     light-weight and quicker than collecting a record per activation.
     The statistic function is configured in the constructor.
 
-    collector_direction - enum type: IN for IFMs, OUT for IFM
+    collector_direction - enum type: IN for IFMs, OUT for OFM
     inputs_consolidate_func is called on tuple of tensors, and returns a tensor.
     """
     def __init__(self, model, stat_name, summary_fn,

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -205,15 +205,16 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
     light-weight and quicker than collecting a record per activation.
     The statistic function is configured in the constructor.
 
+    output_flag - When True collect on OFM, otherwise, IFMs
     inputs_consolidate_func is called on tuple of tensors, and returns a tensor.
     """
     def __init__(self, model, stat_name, summary_fn,
                  classes=[torch.nn.ReLU, torch.nn.ReLU6, torch.nn.LeakyReLU],
-                 in_or_out='out',
+                 output_flag=True,
                  inputs_consolidate_func:typing.Callable[[typing.Sequence[TensorType]], TensorType]=torch.cat):
         super(SummaryActivationStatsCollector, self).__init__(model, stat_name, classes)
         self.summary_fn = summary_fn
-        self.output_flag = (in_or_out == 'out')
+        self.output_flag = output_flag
         self.inputs_func = inputs_consolidate_func
 
     def _activation_stats_cb(self, module, inputs, output):

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -17,7 +17,6 @@
 import contextlib
 from functools import partial, reduce
 import operator
-import typing
 import xlsxwriter
 import yaml
 import os
@@ -42,7 +41,6 @@ __all__ = ['SummaryActivationStatsCollector', 'RecordsActivationStatsCollector',
            'collect_quant_stats', 'collect_histograms',
            'collector_context', 'collectors_context']
 
-TensorType = typing.TypeVar('TensorType')
 
 class ActivationStatsCollector(object):
     """Collect model activation statistics information.
@@ -210,8 +208,7 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
     """
     def __init__(self, model, stat_name, summary_fn,
                  classes=[torch.nn.ReLU, torch.nn.ReLU6, torch.nn.LeakyReLU],
-                 output_flag=True,
-                 inputs_consolidate_func:typing.Callable[[typing.Sequence[TensorType]], TensorType]=torch.cat):
+                 output_flag=True, inputs_consolidate_func=torch.cat):
         super(SummaryActivationStatsCollector, self).__init__(model, stat_name, classes)
         self.summary_fn = summary_fn
         self.output_flag = output_flag

--- a/distiller/data_loggers/collector.py
+++ b/distiller/data_loggers/collector.py
@@ -267,6 +267,7 @@ class SummaryActivationStatsCollector(ActivationStatsCollector):
             activation_stats[getattr(module, self.stat_name).name] = mean
 
     def save(self, fname):
+        """Save the stats to an Excel workbook"""
         if not fname.endswith('.xlsx'):
             fname = '.'.join([fname, 'xlsx'])
         with contextlib.suppress(OSError):


### PR DESCRIPTION
Patch adds support to collecting IFM sparsity, as well as multiple IFMs. If multiple IFMs are present, they are merged with `torch.cat`, which is a parameter to the collector.
IFM sparsity will be collected whenever activation sparsity is collected with `create_activation_stats_collectors`.
Renamed some of the fields/filenames.

Tested against Python3.6. Passed ~~excluding the post-training tests.~~ (merged @guyjacob bugfix)
Note the use of typing library for type hinting. Not sure about the state of support for this in older Python 3.5 environments. It's possible that this patch requires Python3.6 OR Python3.5+updates, but not sure how to check that.