### PR TITLE
Post-Train Quant LAPQ Refactoring

### DIFF
--- a/distiller/apputils/image_classifier.py
+++ b/distiller/apputils/image_classifier.py
@@ -204,13 +204,13 @@ class ClassifierCompressor(object):
                     self.pylogger, self.activations_collectors, args=self.args)
 
 
-def init_classifier_compression_arg_parser():
+def init_classifier_compression_arg_parser(include_ptq_lapq_args=False):
     '''Common classifier-compression application command-line arguments.
     '''
     SUMMARY_CHOICES = ['sparsity', 'compute', 'model', 'modules', 'png', 'png_w_params']
 
     parser = argparse.ArgumentParser(description='Distiller image classification model compression')
-    parser.add_argument('data', metavar='DIR', help='path to dataset')
+    parser.add_argument('data', metavar='DATASET_DIR', help='path to dataset')
     parser.add_argument('--arch', '-a', metavar='ARCH', default='resnet18', type=lambda s: s.lower(),
                         choices=models.ALL_MODEL_NAMES,
                         help='model architecture: ' +
@@ -312,7 +312,7 @@ def init_classifier_compression_arg_parser():
                         help='Load a model without DataParallel wrapping it')
     parser.add_argument('--thinnify', dest='thinnify', action='store_true', default=False,
                         help='physically remove zero-filters and create a smaller model')
-    distiller.quantization.add_post_train_quant_args(parser)
+    distiller.quantization.add_post_train_quant_args(parser, add_lapq_args=include_ptq_lapq_args)
     return parser
 
 

--- a/distiller/quantization/range_linear.py
+++ b/distiller/quantization/range_linear.py
@@ -268,7 +268,7 @@ def linear_dequantize_with_metadata(t, inplace=False):
     return t
 
 
-def add_post_train_quant_args(argparser):
+def add_post_train_quant_args(argparser, add_lapq_args=False):
     str_to_quant_mode_map = OrderedDict([
         ('sym', LinearQuantMode.SYMMETRIC),
         ('sym_restr', LinearQuantMode.SYMMETRIC_RESTRICTED),
@@ -293,8 +293,7 @@ def add_post_train_quant_args(argparser):
     linear_quant_mode_str_optional = partial(from_dict, d=str_to_quant_mode_map, optional=True)
     clip_mode_str = partial(from_dict, d=str_to_clip_mode_map, optional=False)
 
-    group = argparser.add_argument_group('Arguments controlling quantization at evaluation time '
-                                         '("post-training quantization")')
+    group = argparser.add_argument_group('Post-Training Quantization Arguments')
     group.add_argument('--quantize-eval', '--qe', action='store_true',
                        help='Apply linear quantization to model before evaluation. Applicable only if '
                             '--evaluate is also set')
@@ -338,15 +337,21 @@ def add_post_train_quant_args(argparser):
 
     stats_group = group.add_mutually_exclusive_group()
     stats_group.add_argument('--qe-stats-file', type=str, metavar='PATH',
-                       help='Path to YAML file with pre-made calibration stats')
+                             help='Path to YAML file with pre-made calibration stats')
     stats_group.add_argument('--qe-dynamic', action='store_true', help='Apply dynamic quantization')
     stats_group.add_argument('--qe-calibration', type=distiller.utils.float_range_argparse_checker(exc_min=True),
-                       metavar='PORTION_OF_TEST_SET', default=None,
-                       help='Run the model in evaluation mode on the specified portion of the test dataset and '
-                            'collect statistics')
+                             metavar='PORTION_OF_TEST_SET', default=None,
+                             help='Run the model in evaluation mode on the specified portion of the test dataset and '
+                                  'collect statistics')
     stats_group.add_argument('--qe-config-file', type=str, metavar='PATH',
-                       help='Path to YAML file containing configuration for PostTrainLinearQuantizer (if present, '
-                            'all other --qe* arguments are ignored)')
+                             help='Path to YAML file containing configuration for PostTrainRLinearQuantizer '
+                                  '(if present, all other --qe* arguments are ignored)')
+
+    if add_lapq_args:
+        from .ptq_coordinate_search import add_coordinate_search_args
+        group.add_argument('--qe-lapq', '--qe-coordinate-search', action='store_true',
+                           help='Optimize post-training quantization parameters using LAPQ method')
+        add_coordinate_search_args(argparser)
 
 
 class UnsatisfiedRequirements(Exception):
@@ -1597,15 +1602,6 @@ class PostTrainLinearQuantizer(Quantizer):
                     model_activation_stats = distiller.utils.yaml_ordered_load(stream)
             elif not isinstance(model_activation_stats, (dict, OrderedDict)):
                 raise TypeError('model_activation_stats must either be a string, a dict / OrderedDict or None')
-        else:
-            msglogger.warning("\nWARNING:\nNo stats file passed - Dynamic quantization will be used\n"
-                              "At the moment, this mode isn't as fully featured as stats-based quantization, and "
-                              "the accuracy results obtained are likely not as representative of real-world results."
-                              "\nSpecifically:\n"
-                              "  * Not all modules types are supported in this mode. Unsupported modules will remain "
-                              "in FP32.\n"
-                              "  * Optimizations for quantization of layers followed by Relu/Tanh/Sigmoid are only "
-                              "supported when statistics are used.\nEND WARNING\n")
 
         mode_dict = {'activations': _enum_to_str(mode.activations), 'weights': _enum_to_str(mode.weights)}
         self.model.quantizer_metadata = {'type': type(self),
@@ -1928,6 +1924,16 @@ class PostTrainLinearQuantizer(Quantizer):
         msglogger.info('Per-layer quantization parameters saved to ' + save_path)
 
     def prepare_model(self, dummy_input=None):
+        if not self.model_activation_stats:
+            msglogger.warning("\nWARNING:\nNo stats file passed - Dynamic quantization will be used\n"
+                              "At the moment, this mode isn't as fully featured as stats-based quantization, and "
+                              "the accuracy results obtained are likely not as representative of real-world results."
+                              "\nSpecifically:\n"
+                              "  * Not all modules types are supported in this mode. Unsupported modules will remain "
+                              "in FP32.\n"
+                              "  * Optimizations for quantization of layers followed by Relu/Tanh/Sigmoid are only "
+                              "supported when statistics are used.\nEND WARNING\n")
+
         self.has_bidi_distiller_lstm = any(isinstance(m, distiller.modules.DistillerLSTM) and m.bidirectional for
                                            _, m in self.model.named_modules())
         if self.has_bidi_distiller_lstm:

--- a/examples/classifier_compression/README.md
+++ b/examples/classifier_compression/README.md
@@ -34,6 +34,7 @@ A non-exhaustive list of the methods implemented:
 ### Quantization
 
 - [Post-training quantization](https://github.com/NervanaSystems/distiller/tree/master/examples/quantization/post_train_quant/command_line.md) based on the TensorFlow quantization scheme (originally GEMMLOWP) with additional capabilities.
+  - Optimizing post-training quantization parameters with the [LAPQ](https://arxiv.org/abs/1911.07190) method - see [example YAML](https://github.com/NervanaSystems/distiller/blob/master/examples/quantization/post_train_quant/resnet18_imagenet_post_train_lapq.yaml) file for details.
 - [Quantization-aware training](https://github.com/NervanaSystems/distiller/tree/master/examples/quantization/quant_aware_train): TensorFlow scheme, DoReFa, PACT
 
 ### Knowledge Distillation

--- a/examples/classifier_compression/parser.py
+++ b/examples/classifier_compression/parser.py
@@ -16,7 +16,7 @@
 
 import argparse
 import distiller
-import distiller.quantization
+import distiller.pruning
 import distiller.models as models
 
 

--- a/examples/classifier_compression/ptq_lapq.py
+++ b/examples/classifier_compression/ptq_lapq.py
@@ -1,0 +1,99 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import torch
+from copy import deepcopy
+import logging
+from collections import OrderedDict
+
+import distiller
+import distiller.apputils as apputils
+import distiller.apputils.image_classifier as classifier
+import distiller.quantization.ptq_coordinate_search as lapq
+
+
+msglogger = logging.getLogger()
+
+
+def image_classifier_ptq_lapq(model, criterion, loggers, args):
+    args = deepcopy(args)
+
+    effective_test_size_bak = args.effective_test_size
+    args.effective_test_size = args.lapq_eval_size
+    eval_data_loader = classifier.load_data(args, load_train=False, load_val=False, load_test=True, fixed_subset=True)
+
+    args.effective_test_size = effective_test_size_bak
+    test_data_loader = classifier.load_data(args, load_train=False, load_val=False, load_test=True)
+
+    model = model.eval()
+    device = next(model.parameters()).device
+
+    if args.lapq_eval_memoize_dataloader:
+        images_batches = []
+        targets_batches = []
+        for images, targets in eval_data_loader:
+            images_batches.append(images.to(device))
+            targets_batches.append(targets.to(device))
+        memoized_data_loader = [(torch.cat(images_batches), torch.cat(targets_batches))]
+    else:
+        memoized_data_loader = None
+
+    def eval_fn(model):
+        if memoized_data_loader:
+            loss = 0
+            for images, targets in memoized_data_loader:
+                outputs = model(images)
+                loss += criterion(outputs, targets).item()
+            loss = loss / len(memoized_data_loader)
+        else:
+            _, _, loss = classifier.test(eval_data_loader, model, criterion, loggers, None, args)
+        return loss
+
+    def test_fn(model):
+        top1, top5, loss = classifier.test(test_data_loader, model, criterion, loggers, None, args)
+        return OrderedDict([('top-1', top1), ('top-5', top5), ('loss', loss)])
+
+    args.device = device
+    if args.resumed_checkpoint_path:
+        args.load_model_path = args.resumed_checkpoint_path
+    if args.load_model_path:
+        msglogger.info("Loading checkpoint from %s" % args.load_model_path)
+        model = apputils.load_lean_checkpoint(model, args.load_model_path,
+                                              model_device=args.device)
+
+    quantizer = distiller.quantization.PostTrainLinearQuantizer.from_args(model, args)
+
+    dummy_input = torch.rand(*model.input_shape, device=args.device)
+    model, qp_dict = lapq.ptq_coordinate_search(quantizer, dummy_input, eval_fn, test_fn=test_fn,
+                                                **lapq.cmdline_args_to_dict(args))
+
+    results = test_fn(quantizer.model)
+    msglogger.info("Arch: %s \tTest: \t top1 = %.3f \t top5 = %.3f \t loss = %.3f" %
+                   (args.arch, results['top-1'], results['top-5'], results['loss']))
+    distiller.yaml_ordered_save('%s.quant_params_dict.yaml' % args.arch, qp_dict)
+
+    distiller.apputils.save_checkpoint(0, args.arch, model,
+                                       extras={'top1': results['top-1'], 'qp_dict': qp_dict}, name=args.name,
+                                       dir=msglogger.logdir)
+
+
+if __name__ == "__main__":
+    parser = classifier.init_classifier_compression_arg_parser(include_ptq_lapq_args=True)
+    args = parser.parse_args()
+    args.epochs = float('inf')  # hack for args parsing so there's no error in epochs
+    cc = classifier.ClassifierCompressor(args, script_dir=os.path.dirname(__file__))
+    image_classifier_ptq_lapq(cc.model, cc.criterion, [cc.pylogger, cc.tflogger], cc.args)

--- a/examples/quantization/post_train_quant/command_line.md
+++ b/examples/quantization/post_train_quant/command_line.md
@@ -30,8 +30,9 @@ Post-training quantization can either be configured straight from the command-li
 | `--qe-stats-file`        | N/A       | Use stats file for static quantization of activations. See details below              | None    |
 | `--qe-dynamic`           | N/A       | Perform dynamic quantization. See details below                                       | None    |
 | `--qe-config-file`       | N/A       | Path to YAML config file. See section above. (ignores all other --qe* arguments)      | None    |
-| `--qe-convert-pytorch`   | `--qept`  | Convert the model to PyTorch native post-train quantization modules                   | Off     |
+| `--qe-convert-pytorch`   | `--qept`  | Convert the model to PyTorch native post-train quantization modules. See [tutorial](https://github.com/NervanaSystems/distiller/blob/master/jupyter/post_train_quant_convert_pytorch.ipynb) for more details | Off     |
 | `--qe-pytorch-backend`   | N/A       | When --qe-convert-pytorch is set, specifies the PyTorch quantization backend to use. Choices: "fbgemm", "qnnpack"   | Off     |
+| `--qe-lapq`              | N/A       | Optimize post-training quantization parameters using [LAPQ](https://arxiv.org/abs/1911.07190) method. Beyond the scope of this document. See [example YAML](https://github.com/NervanaSystems/distiller/blob/master/examples/quantization/post_train_quant/resnet18_imagenet_post_train_lapq.yaml) file for details   | Off     |
 
 ### Notes
 
@@ -39,10 +40,6 @@ Post-training quantization can either be configured straight from the command-li
 2. The `--qe-convert-pytorch` works in two settings:
     * `--quantize-eval` is also set, in which case an FP32 model is first quantized using Distiller's post-training quantization flow, and then converted to a PyTorch native quantization model.
     * `--quantize-eval` is not set, but a previously post-train quantized model is loaded via `--resume`. In this case, the loaded model is converted to PyTorch native quantization.
-
-### Conversion to PyTorch Built-in Quantization Model
-
-PyTorch released built-in support for quantization in version 1.3. Currently Distiller's quantization functionality is still completely separate from PyTorch's. We provide the ability to take a model which was post-train quantized with Distiller, and is comprised of `RangeLinearQuantWrapper`
 
 ## "Net-Aware" Quantization
 

--- a/examples/quantization/post_train_quant/resnet18_imagenet_post_train_lapq.yaml
+++ b/examples/quantization/post_train_quant/resnet18_imagenet_post_train_lapq.yaml
@@ -21,7 +21,7 @@ quantizers:
     mode:
       activations: ASYMMETRIC_UNSIGNED
       weights: SYMMETRIC
-    model_activation_stats: ../../examples/quantization/post_train_quant/stats/resnet18_quant_stats.yaml
+    # model_activation_stats: ../quantization/post_train_quant/stats/resnet18_quant_stats.yaml
     per_channel_wts: False
     inputs_quant_auto_fallback: True
 
@@ -47,12 +47,13 @@ quantizers:
 
 # Example invocations:
 #   * Preliminaries:
-#       cd <distiller_root>/distiller/quantization
-#       CONFIG_FILE="../../examples/quantization/post_train_quant/resnet18_imagenet_post_train_lapq.yaml"
+#       cd <distiller_root>/examples/classifier_compression
+#       CONFIG_FILE="../quantization/post_train_quant/resnet18_imagenet_post_train_lapq.yaml"
+#       IMAGENET_PATH=<path_to_imagenet>
 #
 #   * Using L3 initialization:
 #     Command:
-#       python ptq_coordinate_search.py -a resnet18 --pretrained <path_to_imagenet> --opt-val-size 0.01 --opt-maxiter 2 --qe-config-file $CONFIG_FILE -b 500 --opt-init-mode L3 --opt-init-method powell --opt-eval-memoize-dataloader --det --opt-search-clipping
+#       python compress_classifier.py --eval --qe --qe-lapq -a resnet18 --pretrained $IMAGENET_PATH --lapq-eval-size 0.01 --lapq-maxiter 2 --qe-config-file $CONFIG_FILE -b 500 --lapq-init-mode L3 --lapq-init-method powell --lapq-eval-memoize-dataloader --det --lapq-search-clipping
 #
 #     Excerpts from output:
 #       ...
@@ -77,7 +78,7 @@ quantizers:
 #
 #   * Using LAPLACE initialization:
 #     Command:
-#       python ptq_coordinate_search.py -a resnet18 --pretrained <path_to_imagenet> --opt-val-size 0.01 --opt-maxiter 2 --qe-config-file $CONFIG_FILE -b 500 --opt-init-mode LAPLACE --opt-init-method powell --opt-eval-memoize-dataloader --det --opt-search-clipping
+#       python compress_classifier.py --eval --qe --qe-lapq -a resnet18 --pretrained $IMAGENET_PATH --lapq-eval-size 0.01 --lapq-maxiter 2 --qe-config-file $CONFIG_FILE -b 500 --lapq-init-mode LAPLACE --lapq-init-method powell --lapq-eval-memoize-dataloader --det --lapq-search-clipping
 #
 #     Excerpts from output:
 #       ...


### PR DESCRIPTION
* Move image classification specific setup code to separate script at `examples/classifier_compression/ptq_lapq.py`
* Make ptq_coordinate_search function completely independent of command line arguments
* Change LAPQ command line args function to update existing pre-existing parser (changed CLAs perfix to 'lapq' for more clarity)
* Enable LAPQ from compress_classifier.py (trigger with `--qe-lapq`)
* Add pointers in documentation